### PR TITLE
feat: execute roadmap Phase 5 chat triage and routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Mutual Hub (Phase 3 Baseline)
+# Mutual Hub (Phase 5 Baseline)
 
-This repository is scaffolded through **Phase 3** of roadmap issue #41.
+This repository is scaffolded through **Phase 5** of roadmap issue #41.
 
 ## Stack
 
@@ -26,6 +26,20 @@ This repository is scaffolded through **Phase 3** of roadmap issue #41.
 - Server-side query APIs for map/feed/directory with validation, filters, and pagination.
 - Deterministic ranking pipeline combining distance band, recency, and trust signals.
 
+## Phase 4 additions
+
+- Shared discovery filter model + chip primitives for map/feed surfaces.
+- Map UX logic for clustering, approximate markers, and detail drawer actions.
+- Feed UX logic for latest/nearby tabs and post lifecycle interactions.
+- Shared posting form validation + geoprivacy payload shaping.
+
+## Phase 5 additions
+
+- Post-linked 1:1 chat initiation contract with map/feed/detail source context.
+- Deterministic routing assistant for post author vs volunteer pool vs verified resource.
+- Conversation metadata persistence with recipient-capability fallback notices.
+- Chat safety controls: block/mute/report, abuse keyword flagging, and rate limits.
+
 ## Service boundaries
 
 - **API service**: request/response boundary for web clients and downstream contracts.
@@ -42,6 +56,7 @@ Detailed domain and boundary docs:
 - `docs/at-protocol/identity-session.md`
 - `docs/at-protocol/tombstone-contract.md`
 - `docs/architecture/phase3-ingestion-query.md`
+- `docs/architecture/phase5-chat-routing.md`
 
 ## Local setup
 
@@ -64,12 +79,20 @@ Each backend service exposes a health endpoint:
 - Indexer: `GET http://localhost:4100/health`
 - Moderation worker: `GET http://localhost:4200/health`
 
-Phase 3 service endpoints:
+Phase 5 service endpoints:
 
 - API:
     - `GET /query/map`
     - `GET /query/feed`
     - `GET /query/directory`
+    - `GET /chat/initiate`
+    - `GET /chat/route`
+    - `GET /chat/conversations`
+    - `GET /chat/safety/evaluate`
+    - `GET /chat/safety/block`
+    - `GET /chat/safety/mute`
+    - `GET /chat/safety/report`
+    - `GET /chat/safety/signals/drain`
 - Indexer:
     - `GET /ingestion/metrics`
     - `GET /ingestion/logs`

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -14,14 +14,14 @@ export const App = () => {
                 <h1 className='font-heading text-4xl font-black uppercase'>
                     {APP_TITLE}
                 </h1>
-                <Badge tone='danger'>Phase 4 baseline</Badge>
+                <Badge tone='danger'>Phase 5 baseline</Badge>
             </header>
 
             <div className='grid gap-6 md:grid-cols-2'>
                 <Panel title='Discovery shell'>
                     <p className='mb-3 text-sm text-[var(--mh-text-muted)]'>
                         Vite + React + TypeScript + Tailwind are wired and ready
-                        for Phase 2 feature work.
+                        for Phase 5 chat triage and routing.
                     </p>
                     <label className='mb-2 block text-xs font-bold uppercase tracking-wide'>
                         Search requests

--- a/apps/web/src/chat-ux.test.ts
+++ b/apps/web/src/chat-ux.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import {
+    buildChatInitiationRequest,
+    defaultChatLaunchState,
+    isChatInitiationAllowed,
+    reduceChatLaunchState,
+    toChatStatusNotice,
+    type ChatInitiationIntent,
+} from './chat-ux.js';
+
+const mapIntent: ChatInitiationIntent = {
+    aidPostUri: 'at://did:example:alice/app.mutualhub.aid.post/post-map',
+    aidPostTitle: 'Need groceries',
+    recipientDid: 'did:example:alice',
+    initiatedFrom: 'map',
+};
+
+const feedIntent: ChatInitiationIntent = {
+    aidPostUri: 'at://did:example:alice/app.mutualhub.aid.post/post-feed',
+    aidPostTitle: 'Need shelter',
+    recipientDid: 'did:example:alice',
+    initiatedFrom: 'feed',
+};
+
+describe('chat ux', () => {
+    it('builds initiation payloads from map and feed entry surfaces', () => {
+        const mapRequest = buildChatInitiationRequest(
+            mapIntent,
+            'did:example:helper',
+        );
+        const feedRequest = buildChatInitiationRequest(
+            feedIntent,
+            'did:example:helper',
+        );
+
+        expect(mapRequest.initiatedFrom).toBe('map');
+        expect(feedRequest.initiatedFrom).toBe('feed');
+        expect(mapRequest.recipientDid).toBe('did:example:alice');
+    });
+
+    it('enforces permission and identity gating for initiation', () => {
+        expect(
+            isChatInitiationAllowed({
+                initiatedByDid: 'did:example:helper',
+                recipientDid: 'did:example:alice',
+                hasPermission: true,
+            }),
+        ).toBe(true);
+
+        expect(
+            isChatInitiationAllowed({
+                initiatedByDid: 'did:example:alice',
+                recipientDid: 'did:example:alice',
+                hasPermission: true,
+            }),
+        ).toBe(false);
+
+        expect(
+            isChatInitiationAllowed({
+                initiatedByDid: 'did:example:helper',
+                recipientDid: 'did:example:alice',
+                hasPermission: false,
+            }),
+        ).toBe(false);
+    });
+
+    it('shows explicit fallback notice when recipient capability is missing', () => {
+        const submitting = reduceChatLaunchState(defaultChatLaunchState, {
+            type: 'submit',
+            intent: mapIntent,
+        });
+        expect(submitting.status).toBe('submitting');
+
+        const successWithFallback = reduceChatLaunchState(submitting, {
+            type: 'success',
+            intent: mapIntent,
+            result: {
+                conversationUri:
+                    'at://did:example:alice/app.mutualhub.conversation.meta/conv-1',
+                created: true,
+                transportPath: 'manual-fallback',
+                fallbackNotice: {
+                    code: 'RECIPIENT_CAPABILITY_MISSING',
+                    message:
+                        'Recipient cannot receive AT-native chat yet. We will use a safe fallback handoff path.',
+                    safeForUser: true,
+                    transportPath: 'manual-fallback',
+                },
+            },
+        });
+
+        const notice = toChatStatusNotice(successWithFallback);
+        expect(notice?.tone).toBe('warning');
+        expect(notice?.message).toContain('safe fallback handoff path');
+    });
+
+    it('converts failure state into actionable danger notice', () => {
+        const failure = reduceChatLaunchState(defaultChatLaunchState, {
+            type: 'failure',
+            intent: feedIntent,
+            errorMessage: 'Unauthorized initiation. Please verify participant access.',
+        });
+
+        const notice = toChatStatusNotice(failure);
+        expect(notice?.tone).toBe('danger');
+        expect(notice?.message).toContain('Unauthorized initiation');
+    });
+});

--- a/apps/web/src/chat-ux.ts
+++ b/apps/web/src/chat-ux.ts
@@ -1,0 +1,147 @@
+export type ChatEntrySurface = 'map' | 'feed' | 'detail';
+
+export interface ChatInitiationIntent {
+    aidPostUri: string;
+    aidPostTitle: string;
+    recipientDid: string;
+    initiatedFrom: ChatEntrySurface;
+}
+
+export interface ChatInitiationRequest {
+    aidPostUri: string;
+    initiatedByDid: string;
+    recipientDid: string;
+    initiatedFrom: ChatEntrySurface;
+}
+
+export interface ChatFallbackNotice {
+    code: 'RECIPIENT_CAPABILITY_MISSING';
+    message: string;
+    safeForUser: true;
+    transportPath: 'resource-fallback' | 'manual-fallback';
+}
+
+export interface ChatLaunchSuccess {
+    conversationUri: string;
+    created: boolean;
+    transportPath: 'atproto-direct' | 'resource-fallback' | 'manual-fallback';
+    fallbackNotice?: ChatFallbackNotice;
+}
+
+export interface ChatLaunchState {
+    status: 'idle' | 'submitting' | 'success' | 'error';
+    surface?: ChatEntrySurface;
+    conversationUri?: string;
+    fallbackNotice?: ChatFallbackNotice;
+    errorMessage?: string;
+}
+
+export type ChatLaunchEvent =
+    | {
+          type: 'submit';
+          intent: ChatInitiationIntent;
+      }
+    | {
+          type: 'success';
+          intent: ChatInitiationIntent;
+          result: ChatLaunchSuccess;
+      }
+    | {
+          type: 'failure';
+          intent: ChatInitiationIntent;
+          errorMessage: string;
+      }
+    | {
+          type: 'reset';
+      };
+
+export const defaultChatLaunchState: Readonly<ChatLaunchState> = Object.freeze({
+    status: 'idle' as const,
+});
+
+export const buildChatInitiationRequest = (
+    intent: ChatInitiationIntent,
+    initiatedByDid: string,
+): ChatInitiationRequest => {
+    return {
+        aidPostUri: intent.aidPostUri,
+        initiatedByDid,
+        recipientDid: intent.recipientDid,
+        initiatedFrom: intent.initiatedFrom,
+    };
+};
+
+export const isChatInitiationAllowed = (input: {
+    initiatedByDid: string;
+    recipientDid: string;
+    hasPermission: boolean;
+}): boolean => {
+    if (!input.hasPermission) {
+        return false;
+    }
+
+    return input.initiatedByDid !== input.recipientDid;
+};
+
+export const reduceChatLaunchState = (
+    _current: ChatLaunchState,
+    event: ChatLaunchEvent,
+): ChatLaunchState => {
+    if (event.type === 'reset') {
+        return { ...defaultChatLaunchState };
+    }
+
+    if (event.type === 'submit') {
+        return {
+            status: 'submitting',
+            surface: event.intent.initiatedFrom,
+        };
+    }
+
+    if (event.type === 'success') {
+        return {
+            status: 'success',
+            surface: event.intent.initiatedFrom,
+            conversationUri: event.result.conversationUri,
+            fallbackNotice: event.result.fallbackNotice,
+        };
+    }
+
+    return {
+        status: 'error',
+        surface: event.intent.initiatedFrom,
+        errorMessage: event.errorMessage,
+    };
+};
+
+export interface ChatStatusNotice {
+    tone: 'success' | 'warning' | 'danger';
+    message: string;
+}
+
+export const toChatStatusNotice = (
+    state: ChatLaunchState,
+): ChatStatusNotice | undefined => {
+    if (state.status === 'error' && state.errorMessage) {
+        return {
+            tone: 'danger',
+            message: state.errorMessage,
+        };
+    }
+
+    if (state.status === 'success' && state.fallbackNotice) {
+        return {
+            tone: 'warning',
+            message: state.fallbackNotice.message,
+        };
+    }
+
+    if (state.status === 'success' && state.conversationUri) {
+        return {
+            tone: 'success',
+            message: `Chat ready: ${state.conversationUri}`,
+        };
+    }
+
+    return undefined;
+};

--- a/apps/web/src/index.ts
+++ b/apps/web/src/index.ts
@@ -1,4 +1,5 @@
 export * from './app-shell.js';
+export * from './chat-ux.js';
 export * from './discovery-filters.js';
 export * from './discovery-primitives.js';
 export * from './feed-ux.js';

--- a/docs/architecture/phase5-chat-routing.md
+++ b/docs/architecture/phase5-chat-routing.md
@@ -1,0 +1,85 @@
+# Phase 5 chat triage and routing (P5.1-P5.4)
+
+This document captures the Phase 5 implementation scope for roadmap issue #41.
+
+## Modules
+
+- Shared chat domain + rules: `packages/shared/src/messaging.ts`
+- Shared Phase 5 tests: `packages/shared/src/messaging.test.ts`
+- API chat adapter: `services/api/src/chat-service.ts`
+- API route wiring: `services/api/src/index.ts`
+- API Phase 5 tests: `services/api/src/phase5.test.ts`
+- Web chat UX state model: `apps/web/src/chat-ux.ts`
+- Web chat UX tests: `apps/web/src/chat-ux.test.ts`
+
+## P5.1 post-linked 1:1 initiation
+
+`createPostLinkedChatContext` builds deterministic 1:1 conversation context from map/feed/detail surfaces.
+
+Key behaviors:
+
+- Validates participant identity (`did:*`) and post URI (`at://...`).
+- Rejects self-chat and unauthorized initiation attempts.
+- Produces deterministic conversation URI from `(aidPostUri, sorted participants)`.
+- Persists request context metadata for source surface (`map | feed | detail`).
+
+## P5.2 deterministic routing assistant
+
+`DeterministicRoutingAssistant` selects destination in strict deterministic priority order:
+
+1. Post author
+2. Volunteer pool
+3. Verified resource
+4. Manual fallback
+
+Rule output includes:
+
+- Stable `matchedRule`
+- Ordered scored candidates
+- Machine-readable reasons
+- Human-readable rationale
+
+Tie-breakers are deterministic (`priority desc`, then `destinationId asc`).
+
+## P5.3 metadata persistence + recipient capability fallback
+
+`ConversationMetadataStore` persists conversation metadata records (`app.mutualhub.conversation.meta`) and keeps them queryable by:
+
+- Conversation URI
+- Aid post URI
+- Fallback-required subset
+
+Capability handling:
+
+- Transport path resolves to `atproto-direct`, `resource-fallback`, or `manual-fallback`.
+- Missing AT-native capability emits explicit user-safe fallback notice.
+
+## P5.4 safety controls and abuse protections
+
+`ChatSafetyControls` provides:
+
+- Participant block controls
+- Conversation mute controls
+- Keyword abuse flagging with moderation signal hooks
+- Sliding-window rate limiting with explicit user feedback
+- Moderation report creation (`app.mutualhub.moderation.report`) with emitted review signals
+
+## API routes added
+
+- `GET /chat/initiate`
+- `GET /chat/route`
+- `GET /chat/conversations`
+- `GET /chat/safety/evaluate`
+- `GET /chat/safety/block`
+- `GET /chat/safety/mute`
+- `GET /chat/safety/report`
+- `GET /chat/safety/signals/drain`
+
+## Test coverage
+
+- Deterministic initiation and authorization rejection
+- Fixture-driven routing decisions and tie-break determinism
+- Capability fallback persistence/query behavior
+- Block/mute/report/keyword/rate-limit safety scenarios
+- API-level initiation paths from map + feed
+- Web UX-level fallback notice and error/success state transitions

--- a/packages/shared/src/contracts.ts
+++ b/packages/shared/src/contracts.ts
@@ -1,4 +1,4 @@
-export const CONTRACT_VERSION = '0.3.0-phase3';
+export const CONTRACT_VERSION = '0.5.0-phase5';
 
 export type DomainName =
     | 'identity'
@@ -108,6 +108,31 @@ export interface ApiQueryErrorResponse {
     };
 }
 
+export interface ApiChatInitiationRequest {
+    aidPostUri: string;
+    initiatedByDid: string;
+    recipientDid: string;
+    initiatedFrom: 'map' | 'feed' | 'detail';
+}
+
+export interface ApiChatInitiationResponse {
+    conversationUri: string;
+    created: boolean;
+    transportPath: 'atproto-direct' | 'resource-fallback' | 'manual-fallback';
+    fallbackNotice?: {
+        code: 'RECIPIENT_CAPABILITY_MISSING';
+        message: string;
+        safeForUser: true;
+    };
+}
+
+export interface ApiChatSafetyEvaluationResponse {
+    allowed: boolean;
+    code: 'OK' | 'BLOCKED' | 'RATE_LIMITED' | 'ABUSE_FLAGGED';
+    userMessage: string;
+    matchedKeywords: string[];
+}
+
 export interface IndexerNormalizedAidEvent {
     eventId: string;
     atUri: string;
@@ -183,6 +208,19 @@ export const serviceContractStubs = {
             hasNextPage: false,
             results: [],
         } satisfies ApiQueryAidResponse,
+        chatInitiation: {
+            aidPostUri:
+                'at://did:example:alice/app.mutualhub.aid.post/post-123',
+            initiatedByDid: 'did:example:helper',
+            recipientDid: 'did:example:alice',
+            initiatedFrom: 'map',
+        } satisfies ApiChatInitiationRequest,
+        chatInitiationResponse: {
+            conversationUri:
+                'at://did:example:alice/app.mutualhub.conversation.meta/conv-123',
+            created: true,
+            transportPath: 'atproto-direct',
+        } satisfies ApiChatInitiationResponse,
     },
     indexer: {
         event: {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -3,6 +3,7 @@ export * from './contracts.js';
 export * from './discovery.js';
 export * from './firehose.js';
 export * from './identity.js';
+export * from './messaging.js';
 export * from './ranking.js';
 export * from '@mutual-hub/at-lexicons';
 export * from './records.js';

--- a/packages/shared/src/messaging.test.ts
+++ b/packages/shared/src/messaging.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it } from 'vitest';
+import {
+    ChatFlowError,
+    ChatSafetyControls,
+    ConversationMetadataStore,
+    DeterministicRoutingAssistant,
+    buildPhase5RoutingFixtures,
+    createPostLinkedChatContext,
+} from './messaging.js';
+
+describe('P5.1 post-linked 1:1 chat initiation', () => {
+    it('creates deterministic conversation context from map/feed surfaces', () => {
+        const fromMap = createPostLinkedChatContext({
+            aidPostUri: 'at://did:example:alice/app.mutualhub.aid.post/post-1',
+            initiatedByDid: 'did:example:helper',
+            recipientDid: 'did:example:alice',
+            initiatedFrom: 'map',
+            now: '2026-02-26T15:00:00.000Z',
+        });
+
+        const fromFeed = createPostLinkedChatContext({
+            aidPostUri: 'at://did:example:alice/app.mutualhub.aid.post/post-1',
+            initiatedByDid: 'did:example:helper',
+            recipientDid: 'did:example:alice',
+            initiatedFrom: 'feed',
+            now: '2026-02-26T15:01:00.000Z',
+        });
+
+        expect(fromMap.conversationUri).toBe(fromFeed.conversationUri);
+        expect(fromMap.record.participantDids).toEqual([
+            'did:example:alice',
+            'did:example:helper',
+        ]);
+        expect(fromMap.requestContext.initiatedFrom).toBe('map');
+    });
+
+    it('blocks unauthorized chat initiation with actionable error code', () => {
+        expect(() =>
+            createPostLinkedChatContext({
+                aidPostUri:
+                    'at://did:example:alice/app.mutualhub.aid.post/post-2',
+                initiatedByDid: 'did:example:helper',
+                recipientDid: 'did:example:alice',
+                initiatedFrom: 'detail',
+                allowedParticipantDids: ['did:example:alice'],
+            }),
+        ).toThrowError(ChatFlowError);
+    });
+});
+
+describe('P5.2 deterministic routing assistant', () => {
+    it('matches fixture scenarios with deterministic rule outputs', () => {
+        const assistant = new DeterministicRoutingAssistant();
+        const fixtures = buildPhase5RoutingFixtures();
+
+        for (const fixture of fixtures) {
+            const result = assistant.decide(fixture.input);
+            expect(result.matchedRule).toBe(fixture.expectedRule);
+            expect(result.destinationKind).toBe(fixture.expectedDestinationKind);
+            expect(result.machineRationale.length).toBeGreaterThan(0);
+            expect(result.humanRationale.length).toBeGreaterThan(0);
+        }
+    });
+
+    it('uses deterministic tie-break ordering when priorities match', () => {
+        const assistant = new DeterministicRoutingAssistant();
+
+        const result = assistant.decide({
+            aidPostUri: 'at://did:example:alice/app.mutualhub.aid.post/post-3',
+            requesterDid: 'did:example:requester',
+            aidCategory: 'food',
+            urgency: 'medium',
+            volunteerCandidates: [
+                {
+                    id: 'v-b',
+                    did: 'did:example:v-b',
+                    availability: 'within-24h',
+                    trustScore: 0.5,
+                    matchesCategory: true,
+                },
+                {
+                    id: 'v-a',
+                    did: 'did:example:v-a',
+                    availability: 'within-24h',
+                    trustScore: 0.5,
+                    matchesCategory: true,
+                },
+            ],
+            resourceCandidates: [],
+            now: '2026-02-26T15:10:00.000Z',
+        });
+
+        expect(result.destinationKind).toBe('volunteer-pool');
+        expect(result.destinationId).toBe('volunteer:v-a');
+    });
+});
+
+describe('P5.3 conversation metadata + capability fallback', () => {
+    it('persists queryable metadata and emits explicit fallback notice', () => {
+        const assistant = new DeterministicRoutingAssistant();
+        const store = new ConversationMetadataStore();
+
+        const chat = createPostLinkedChatContext({
+            aidPostUri: 'at://did:example:alice/app.mutualhub.aid.post/post-4',
+            initiatedByDid: 'did:example:helper',
+            recipientDid: 'did:example:alice',
+            initiatedFrom: 'feed',
+            now: '2026-02-26T15:20:00.000Z',
+        });
+
+        const routing = assistant.decide({
+            aidPostUri: chat.requestContext.aidPostUri,
+            requesterDid: 'did:example:helper',
+            aidCategory: 'food',
+            urgency: 'high',
+            postAuthorDid: 'did:example:alice',
+            volunteerCandidates: [],
+            resourceCandidates: [],
+            now: '2026-02-26T15:20:00.000Z',
+        });
+
+        const persisted = store.upsertConversation({
+            chat,
+            routingDecision: routing,
+            recipientCapability: {
+                recipientDid: 'did:example:alice',
+                supportsAtprotoChat: false,
+                fallbackChannels: ['manual-review'],
+                detectedAt: '2026-02-26T15:20:00.000Z',
+            },
+            updatedAt: '2026-02-26T15:21:00.000Z',
+        });
+
+        expect(persisted.transportPath).toBe('manual-fallback');
+        expect(persisted.fallbackNotice?.code).toBe(
+            'RECIPIENT_CAPABILITY_MISSING',
+        );
+
+        const byAidPost = store.listForAidPost(chat.requestContext.aidPostUri);
+        expect(byAidPost).toHaveLength(1);
+        expect(store.listFallbackRequired()).toHaveLength(1);
+    });
+});
+
+describe('P5.4 safety controls + abuse protections', () => {
+    it('supports block/mute/report and rate-limit safety behaviors', () => {
+        const safety = new ChatSafetyControls({
+            maxMessagesPerWindow: 2,
+            windowMs: 10_000,
+            abuseKeywords: ['scam'],
+        });
+
+        safety.blockParticipant('did:example:alice', 'did:example:bad-actor');
+        safety.muteConversation(
+            'did:example:alice',
+            'at://did:example:alice/app.mutualhub.conversation.meta/conv-1',
+        );
+
+        expect(
+            safety.isMuted(
+                'did:example:alice',
+                'at://did:example:alice/app.mutualhub.conversation.meta/conv-1',
+            ),
+        ).toBe(true);
+
+        const blockedAttempt = safety.evaluateOutboundMessage({
+            senderDid: 'did:example:bad-actor',
+            recipientDid: 'did:example:alice',
+            conversationUri:
+                'at://did:example:alice/app.mutualhub.conversation.meta/conv-1',
+            message: 'hello',
+            sentAt: '2026-02-26T15:30:00.000Z',
+        });
+        expect(blockedAttempt.allowed).toBe(false);
+        expect(blockedAttempt.code).toBe('BLOCKED');
+
+        const first = safety.evaluateOutboundMessage({
+            senderDid: 'did:example:helper',
+            recipientDid: 'did:example:alice',
+            conversationUri:
+                'at://did:example:alice/app.mutualhub.conversation.meta/conv-2',
+            message: 'message one',
+            sentAt: '2026-02-26T15:40:00.000Z',
+        });
+        const second = safety.evaluateOutboundMessage({
+            senderDid: 'did:example:helper',
+            recipientDid: 'did:example:alice',
+            conversationUri:
+                'at://did:example:alice/app.mutualhub.conversation.meta/conv-2',
+            message: 'message two',
+            sentAt: '2026-02-26T15:40:02.000Z',
+        });
+        const rateLimited = safety.evaluateOutboundMessage({
+            senderDid: 'did:example:helper',
+            recipientDid: 'did:example:alice',
+            conversationUri:
+                'at://did:example:alice/app.mutualhub.conversation.meta/conv-2',
+            message: 'message three',
+            sentAt: '2026-02-26T15:40:03.000Z',
+        });
+
+        expect(first.code).toBe('OK');
+        expect(second.code).toBe('OK');
+        expect(rateLimited.code).toBe('RATE_LIMITED');
+
+        const abuseFlag = safety.evaluateOutboundMessage({
+            senderDid: 'did:example:helper-2',
+            recipientDid: 'did:example:alice',
+            conversationUri:
+                'at://did:example:alice/app.mutualhub.conversation.meta/conv-3',
+            message: 'This sounds like a scam alert',
+            sentAt: '2026-02-26T15:41:00.000Z',
+        });
+
+        expect(abuseFlag.allowed).toBe(true);
+        expect(abuseFlag.code).toBe('ABUSE_FLAGGED');
+        expect(abuseFlag.matchedKeywords).toEqual(['scam']);
+
+        const report = safety.reportAbuse({
+            subjectUri:
+                'at://did:example:alice/app.mutualhub.conversation.meta/conv-3',
+            reporterDid: 'did:example:alice',
+            reason: 'abuse',
+            details: 'Repeated abuse terms in DMs',
+            createdAt: '2026-02-26T15:41:05.000Z',
+        });
+
+        expect(report.reportRecord.reason).toBe('abuse');
+        expect(report.moderationSignal.type).toBe('moderation.review.requested');
+        expect(safety.drainModerationSignals().length).toBeGreaterThanOrEqual(2);
+    });
+});

--- a/packages/shared/src/messaging.ts
+++ b/packages/shared/src/messaging.ts
@@ -1,0 +1,836 @@
+import { createHash } from 'node:crypto';
+import { z } from 'zod';
+import {
+    recordNsid,
+    type AidPostRecord,
+    type ConversationMetaRecord,
+    type ModerationReportRecord,
+    validateRecordPayload,
+} from '@mutual-hub/at-lexicons';
+import type { ModerationReviewRequestedEvent } from './contracts.js';
+
+const didSchema = z
+    .string()
+    .regex(/^did:[a-z0-9]+:[a-z0-9._:%-]+$/i, 'Expected a valid DID');
+const atUriSchema = z
+    .string()
+    .regex(/^at:\/\/[^\s]+$/i, 'Expected a valid at:// URI');
+const isoDateTimeSchema = z.string().datetime({ offset: true });
+
+const clone = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T;
+
+export type ChatInitiationSurface = 'map' | 'feed' | 'detail';
+
+export type ChatFlowErrorCode =
+    | 'UNAUTHORIZED'
+    | 'INVALID_PARTICIPANTS'
+    | 'INVALID_CONTEXT';
+
+export class ChatFlowError extends Error {
+    constructor(
+        readonly code: ChatFlowErrorCode,
+        message: string,
+        readonly details?: Record<string, unknown>,
+    ) {
+        super(message);
+        this.name = 'ChatFlowError';
+    }
+}
+
+export interface CreatePostLinkedChatInput {
+    aidPostUri: string;
+    initiatedByDid: string;
+    recipientDid: string;
+    initiatedFrom: ChatInitiationSurface;
+    now?: string;
+    allowInitiation?: boolean;
+    allowedParticipantDids?: readonly string[];
+}
+
+export interface PostLinkedChatContext {
+    conversationUri: string;
+    record: ConversationMetaRecord;
+    requestContext: {
+        aidPostUri: string;
+        initiatedFrom: ChatInitiationSurface;
+        initiatedByDid: string;
+        recipientDid: string;
+    };
+}
+
+const buildConversationKey = (
+    aidPostUri: string,
+    participantDids: readonly string[],
+): string => {
+    return createHash('sha256')
+        .update(`${aidPostUri}|${participantDids.join('|')}`)
+        .digest('hex')
+        .slice(0, 24);
+};
+
+const validateInitiationPermission = (
+    input: CreatePostLinkedChatInput,
+): void => {
+    if (input.allowInitiation === false) {
+        throw new ChatFlowError(
+            'UNAUTHORIZED',
+            'Chat initiation is disabled for the current actor.',
+            {
+                initiatedByDid: input.initiatedByDid,
+                recipientDid: input.recipientDid,
+            },
+        );
+    }
+
+    if (input.allowedParticipantDids) {
+        const allowed = new Set(input.allowedParticipantDids);
+        if (
+            !allowed.has(input.initiatedByDid) ||
+            !allowed.has(input.recipientDid)
+        ) {
+            throw new ChatFlowError(
+                'UNAUTHORIZED',
+                'Chat initiation failed participant authorization checks.',
+                {
+                    initiatedByDid: input.initiatedByDid,
+                    recipientDid: input.recipientDid,
+                },
+            );
+        }
+    }
+};
+
+export const createPostLinkedChatContext = (
+    input: CreatePostLinkedChatInput,
+): PostLinkedChatContext => {
+    const aidPostUri = atUriSchema.parse(input.aidPostUri);
+    const initiatedByDid = didSchema.parse(input.initiatedByDid);
+    const recipientDid = didSchema.parse(input.recipientDid);
+
+    if (initiatedByDid === recipientDid) {
+        throw new ChatFlowError(
+            'INVALID_PARTICIPANTS',
+            '1:1 chat initiation requires two distinct participants.',
+            { initiatedByDid, recipientDid },
+        );
+    }
+
+    validateInitiationPermission(input);
+
+    const participantDids = [initiatedByDid, recipientDid].sort(
+        (left, right) => left.localeCompare(right),
+    );
+    const conversationKey = buildConversationKey(aidPostUri, participantDids);
+    const conversationUri = `at://${participantDids[0]}/${recordNsid.conversationMeta}/conv-${conversationKey}`;
+    const now = isoDateTimeSchema.parse(input.now ?? new Date().toISOString());
+
+    const recordCandidate = {
+        $type: recordNsid.conversationMeta,
+        version: '1.0.0',
+        aidPostUri,
+        participantDids,
+        status: 'open',
+        createdAt: now,
+    } satisfies ConversationMetaRecord;
+
+    const record = validateRecordPayload(
+        recordNsid.conversationMeta,
+        recordCandidate,
+    );
+
+    return {
+        conversationUri,
+        record,
+        requestContext: {
+            aidPostUri,
+            initiatedFrom: input.initiatedFrom,
+            initiatedByDid,
+            recipientDid,
+        },
+    };
+};
+
+export interface VolunteerRoutingCandidate {
+    id: string;
+    did: string;
+    availability: 'immediate' | 'within-24h' | 'scheduled' | 'unavailable';
+    trustScore: number;
+    matchesCategory: boolean;
+}
+
+export interface ResourceRoutingCandidate {
+    id: string;
+    verificationStatus: 'unverified' | 'community-verified' | 'partner-verified';
+    supportsCategory: boolean;
+    currentlyOpen: boolean;
+}
+
+export interface RoutingAssistantInput {
+    aidPostUri: string;
+    requesterDid: string;
+    aidCategory: AidPostRecord['category'];
+    urgency: AidPostRecord['urgency'];
+    postAuthorDid?: string;
+    volunteerCandidates: readonly VolunteerRoutingCandidate[];
+    resourceCandidates: readonly ResourceRoutingCandidate[];
+    now?: string;
+}
+
+export interface RoutingCandidateScore {
+    destinationKind:
+        | 'post-author'
+        | 'volunteer-pool'
+        | 'verified-resource'
+        | 'manual-fallback';
+    destinationId: string;
+    priority: number;
+    reasons: string[];
+}
+
+export interface RoutingDecision {
+    destinationKind: RoutingCandidateScore['destinationKind'];
+    destinationId: string;
+    destinationDid?: string;
+    matchedRule:
+        | 'RULE_POST_AUTHOR'
+        | 'RULE_VOLUNTEER_POOL'
+        | 'RULE_VERIFIED_RESOURCE'
+        | 'RULE_MANUAL_FALLBACK';
+    machineRationale: string[];
+    humanRationale: string;
+    priorityOrderUsed: {
+        postAuthor: number;
+        volunteerPool: number;
+        verifiedResource: number;
+    };
+    orderedCandidates: RoutingCandidateScore[];
+    decidedAt: string;
+}
+
+export const ROUTING_PRIORITY_ORDER = Object.freeze({
+    postAuthor: 300,
+    volunteerPool: 200,
+    verifiedResource: 160,
+});
+
+const volunteerAvailabilityBonus = (
+    availability: VolunteerRoutingCandidate['availability'],
+): number => {
+    if (availability === 'immediate') {
+        return 35;
+    }
+    if (availability === 'within-24h') {
+        return 20;
+    }
+    if (availability === 'scheduled') {
+        return 10;
+    }
+    return -1000;
+};
+
+const resourceVerificationBonus = (
+    verificationStatus: ResourceRoutingCandidate['verificationStatus'],
+): number => {
+    if (verificationStatus === 'partner-verified') {
+        return 25;
+    }
+    if (verificationStatus === 'community-verified') {
+        return 10;
+    }
+    return -20;
+};
+
+const toHumanRationale = (candidate: RoutingCandidateScore): string => {
+    if (candidate.destinationKind === 'post-author') {
+        return 'Routing to the original post author for the fastest direct response.';
+    }
+
+    if (candidate.destinationKind === 'volunteer-pool') {
+        return 'Routing to the best-matching volunteer based on availability and trust.';
+    }
+
+    if (candidate.destinationKind === 'verified-resource') {
+        return 'Routing to the strongest verified resource match for this request.';
+    }
+
+    return 'No deterministic recipient qualified; fallback handoff is required.';
+};
+
+const byPriorityThenId = (
+    left: RoutingCandidateScore,
+    right: RoutingCandidateScore,
+): number => {
+    if (left.priority !== right.priority) {
+        return right.priority - left.priority;
+    }
+
+    return left.destinationId.localeCompare(right.destinationId);
+};
+
+export class DeterministicRoutingAssistant {
+    decide(input: RoutingAssistantInput): RoutingDecision {
+        const aidPostUri = atUriSchema.parse(input.aidPostUri);
+        const requesterDid = didSchema.parse(input.requesterDid);
+        const decidedAt = isoDateTimeSchema.parse(
+            input.now ?? new Date().toISOString(),
+        );
+
+        const candidates: RoutingCandidateScore[] = [];
+
+        if (input.postAuthorDid) {
+            const postAuthorDid = didSchema.parse(input.postAuthorDid);
+            if (postAuthorDid !== requesterDid) {
+                candidates.push({
+                    destinationKind: 'post-author',
+                    destinationId: postAuthorDid,
+                    priority: ROUTING_PRIORITY_ORDER.postAuthor,
+                    reasons: [
+                        'post-author-eligible=true',
+                        `aid-post=${aidPostUri}`,
+                    ],
+                });
+            }
+        }
+
+        for (const volunteer of input.volunteerCandidates) {
+            const volunteerDid = didSchema.parse(volunteer.did);
+            const availabilityBonus = volunteerAvailabilityBonus(
+                volunteer.availability,
+            );
+
+            if (availabilityBonus < 0) {
+                continue;
+            }
+
+            const trustScore = Math.max(0, Math.min(1, volunteer.trustScore));
+            const trustBonus = Math.round(trustScore * 20);
+            const categoryBonus = volunteer.matchesCategory ? 12 : 0;
+            const urgencyBonus =
+                input.urgency === 'critical' || input.urgency === 'high' ?
+                    8
+                :   0;
+
+            candidates.push({
+                destinationKind: 'volunteer-pool',
+                destinationId: `volunteer:${volunteer.id}`,
+                priority:
+                    ROUTING_PRIORITY_ORDER.volunteerPool +
+                    availabilityBonus +
+                    trustBonus +
+                    categoryBonus +
+                    urgencyBonus,
+                reasons: [
+                    `availability=${volunteer.availability}`,
+                    `trust=${trustScore.toFixed(2)}`,
+                    `category-match=${volunteer.matchesCategory}`,
+                    `did=${volunteerDid}`,
+                ],
+            });
+        }
+
+        for (const resource of input.resourceCandidates) {
+            if (!resource.supportsCategory || !resource.currentlyOpen) {
+                continue;
+            }
+
+            const verificationBonus = resourceVerificationBonus(
+                resource.verificationStatus,
+            );
+            const urgencyBonus =
+                input.urgency === 'critical' &&
+                resource.verificationStatus !== 'unverified' ?
+                    8
+                :   0;
+
+            candidates.push({
+                destinationKind: 'verified-resource',
+                destinationId: `resource:${resource.id}`,
+                priority:
+                    ROUTING_PRIORITY_ORDER.verifiedResource +
+                    verificationBonus +
+                    urgencyBonus,
+                reasons: [
+                    `verification=${resource.verificationStatus}`,
+                    `supports-category=${resource.supportsCategory}`,
+                    `open=${resource.currentlyOpen}`,
+                ],
+            });
+        }
+
+        const orderedCandidates = [...candidates].sort(byPriorityThenId);
+        const top =
+            orderedCandidates[0] ??
+            ({
+                destinationKind: 'manual-fallback',
+                destinationId: 'manual-fallback',
+                priority: 0,
+                reasons: ['no-candidates-qualified=true'],
+            } satisfies RoutingCandidateScore);
+
+        return {
+            destinationKind: top.destinationKind,
+            destinationId: top.destinationId,
+            destinationDid:
+                top.destinationKind === 'post-author' ? top.destinationId
+                : undefined,
+            matchedRule:
+                top.destinationKind === 'post-author' ?
+                    'RULE_POST_AUTHOR'
+                : top.destinationKind === 'volunteer-pool' ?
+                    'RULE_VOLUNTEER_POOL'
+                : top.destinationKind === 'verified-resource' ?
+                    'RULE_VERIFIED_RESOURCE'
+                :   'RULE_MANUAL_FALLBACK',
+            machineRationale: [...top.reasons],
+            humanRationale: toHumanRationale(top),
+            priorityOrderUsed: { ...ROUTING_PRIORITY_ORDER },
+            orderedCandidates,
+            decidedAt,
+        };
+    }
+}
+
+export interface RecipientTransportCapability {
+    recipientDid: string;
+    supportsAtprotoChat: boolean;
+    fallbackChannels: readonly ('phone' | 'url' | 'manual-review')[];
+    detectedAt: string;
+}
+
+export type ConversationTransportPath =
+    | 'atproto-direct'
+    | 'resource-fallback'
+    | 'manual-fallback';
+
+export interface ConversationFallbackNotice {
+    code: 'RECIPIENT_CAPABILITY_MISSING';
+    message: string;
+    safeForUser: true;
+    transportPath: Exclude<ConversationTransportPath, 'atproto-direct'>;
+}
+
+const resolveTransportPath = (
+    routingDecision: RoutingDecision,
+    capability: RecipientTransportCapability,
+): ConversationTransportPath => {
+    if (capability.supportsAtprotoChat) {
+        return 'atproto-direct';
+    }
+
+    if (routingDecision.destinationKind === 'verified-resource') {
+        return 'resource-fallback';
+    }
+
+    return 'manual-fallback';
+};
+
+const buildFallbackNotice = (
+    transportPath: ConversationTransportPath,
+): ConversationFallbackNotice | undefined => {
+    if (transportPath === 'atproto-direct') {
+        return undefined;
+    }
+
+    return {
+        code: 'RECIPIENT_CAPABILITY_MISSING',
+        message:
+            'Recipient cannot receive AT-native chat yet. We will use a safe fallback handoff path.',
+        safeForUser: true,
+        transportPath,
+    };
+};
+
+export interface PersistConversationMetadataInput {
+    chat: PostLinkedChatContext;
+    routingDecision: RoutingDecision;
+    recipientCapability: RecipientTransportCapability;
+    status?: ConversationMetaRecord['status'];
+    updatedAt?: string;
+}
+
+export interface PersistedConversationMetadata {
+    conversationUri: string;
+    aidPostUri: string;
+    record: ConversationMetaRecord;
+    requestContext: PostLinkedChatContext['requestContext'];
+    routingDecision: RoutingDecision;
+    recipientCapability: RecipientTransportCapability;
+    transportPath: ConversationTransportPath;
+    fallbackNotice?: ConversationFallbackNotice;
+    audit: {
+        lastUpdatedAt: string;
+        moderationQueryableKey: string;
+    };
+}
+
+export class ConversationMetadataStore {
+    private readonly conversations = new Map<string, PersistedConversationMetadata>();
+
+    upsertConversation(
+        input: PersistConversationMetadataInput,
+    ): PersistedConversationMetadata {
+        const conversationUri = atUriSchema.parse(input.chat.conversationUri);
+        const now = isoDateTimeSchema.parse(
+            input.updatedAt ?? new Date().toISOString(),
+        );
+        const existing = this.conversations.get(conversationUri);
+        const status =
+            input.status ?? existing?.record.status ?? input.chat.record.status;
+
+        const recordCandidate = {
+            ...input.chat.record,
+            status,
+            createdAt: existing?.record.createdAt ?? input.chat.record.createdAt,
+            updatedAt: now,
+        } satisfies ConversationMetaRecord;
+
+        const record = validateRecordPayload(
+            recordNsid.conversationMeta,
+            recordCandidate,
+        );
+
+        const recipientDid = didSchema.parse(input.recipientCapability.recipientDid);
+        const capability: RecipientTransportCapability = {
+            ...input.recipientCapability,
+            recipientDid,
+            detectedAt: isoDateTimeSchema.parse(input.recipientCapability.detectedAt),
+        };
+
+        const transportPath = resolveTransportPath(input.routingDecision, capability);
+        const fallbackNotice = buildFallbackNotice(transportPath);
+
+        const persisted: PersistedConversationMetadata = {
+            conversationUri,
+            aidPostUri: record.aidPostUri,
+            record,
+            requestContext: clone(input.chat.requestContext),
+            routingDecision: clone(input.routingDecision),
+            recipientCapability: capability,
+            transportPath,
+            fallbackNotice,
+            audit: {
+                lastUpdatedAt: now,
+                moderationQueryableKey: `${record.aidPostUri}:${record.participantDids.join('|')}`,
+            },
+        };
+
+        this.conversations.set(conversationUri, persisted);
+        return clone(persisted);
+    }
+
+    getConversation(
+        conversationUri: string,
+    ): PersistedConversationMetadata | null {
+        const normalizedUri = atUriSchema.parse(conversationUri);
+        const found = this.conversations.get(normalizedUri);
+        return found ? clone(found) : null;
+    }
+
+    listForAidPost(aidPostUri: string): PersistedConversationMetadata[] {
+        const normalizedAidPostUri = atUriSchema.parse(aidPostUri);
+
+        return [...this.conversations.values()]
+            .filter(conversation => conversation.aidPostUri === normalizedAidPostUri)
+            .sort((left, right) =>
+                left.conversationUri.localeCompare(right.conversationUri),
+            )
+            .map(value => clone(value));
+    }
+
+    listFallbackRequired(): PersistedConversationMetadata[] {
+        return [...this.conversations.values()]
+            .filter(
+                conversation =>
+                    conversation.transportPath !== 'atproto-direct' &&
+                    conversation.fallbackNotice !== undefined,
+            )
+            .sort((left, right) =>
+                left.conversationUri.localeCompare(right.conversationUri),
+            )
+            .map(value => clone(value));
+    }
+}
+
+export interface ChatSafetyEvaluationInput {
+    senderDid: string;
+    recipientDid: string;
+    conversationUri: string;
+    message: string;
+    sentAt?: string;
+}
+
+export interface ChatSafetyEvaluation {
+    allowed: boolean;
+    code: 'OK' | 'BLOCKED' | 'RATE_LIMITED' | 'ABUSE_FLAGGED';
+    userMessage: string;
+    matchedKeywords: string[];
+    moderationSignal?: ModerationReviewRequestedEvent;
+}
+
+export interface ChatSafetyConfig {
+    maxMessagesPerWindow: number;
+    windowMs: number;
+    abuseKeywords: readonly string[];
+}
+
+export interface ReportAbuseInput {
+    subjectUri: string;
+    reporterDid: string;
+    reason: ModerationReportRecord['reason'];
+    details?: string;
+    createdAt?: string;
+}
+
+const defaultSafetyConfig: ChatSafetyConfig = {
+    maxMessagesPerWindow: 4,
+    windowMs: 30_000,
+    abuseKeywords: ['scam', 'fraud', 'abuse', 'threat'],
+};
+
+const getOrCreateSet = (
+    map: Map<string, Set<string>>,
+    key: string,
+): Set<string> => {
+    const value = map.get(key) ?? new Set<string>();
+    map.set(key, value);
+    return value;
+};
+
+export class ChatSafetyControls {
+    private readonly blockedParticipants = new Map<string, Set<string>>();
+    private readonly mutedConversations = new Map<string, Set<string>>();
+    private readonly sendWindows = new Map<string, number[]>();
+    private readonly moderationSignals: ModerationReviewRequestedEvent[] = [];
+
+    constructor(private readonly config: ChatSafetyConfig = defaultSafetyConfig) {}
+
+    blockParticipant(actorDid: string, targetDid: string): void {
+        const actor = didSchema.parse(actorDid);
+        const target = didSchema.parse(targetDid);
+        getOrCreateSet(this.blockedParticipants, actor).add(target);
+    }
+
+    muteConversation(actorDid: string, conversationUri: string): void {
+        const actor = didSchema.parse(actorDid);
+        const uri = atUriSchema.parse(conversationUri);
+        getOrCreateSet(this.mutedConversations, actor).add(uri);
+    }
+
+    isMuted(actorDid: string, conversationUri: string): boolean {
+        const actor = didSchema.parse(actorDid);
+        const uri = atUriSchema.parse(conversationUri);
+        return this.mutedConversations.get(actor)?.has(uri) ?? false;
+    }
+
+    evaluateOutboundMessage(
+        input: ChatSafetyEvaluationInput,
+    ): ChatSafetyEvaluation {
+        const senderDid = didSchema.parse(input.senderDid);
+        const recipientDid = didSchema.parse(input.recipientDid);
+        const conversationUri = atUriSchema.parse(input.conversationUri);
+        const sentAt = isoDateTimeSchema.parse(
+            input.sentAt ?? new Date().toISOString(),
+        );
+
+        const senderBlockedRecipient =
+            this.blockedParticipants.get(senderDid)?.has(recipientDid) ?? false;
+        const recipientBlockedSender =
+            this.blockedParticipants.get(recipientDid)?.has(senderDid) ?? false;
+
+        if (senderBlockedRecipient || recipientBlockedSender) {
+            return {
+                allowed: false,
+                code: 'BLOCKED',
+                userMessage:
+                    'Message cannot be sent because one participant has blocked the other.',
+                matchedKeywords: [],
+            };
+        }
+
+        const nowMs = Date.parse(sentAt);
+        const activeWindow = (this.sendWindows.get(senderDid) ?? []).filter(
+            timestamp => nowMs - timestamp <= this.config.windowMs,
+        );
+
+        if (activeWindow.length >= this.config.maxMessagesPerWindow) {
+            this.sendWindows.set(senderDid, activeWindow);
+            return {
+                allowed: false,
+                code: 'RATE_LIMITED',
+                userMessage:
+                    'You are sending messages too quickly. Please wait before trying again.',
+                matchedKeywords: [],
+            };
+        }
+
+        activeWindow.push(nowMs);
+        this.sendWindows.set(senderDid, activeWindow);
+
+        const normalizedMessage = input.message.trim().toLowerCase();
+        const matchedKeywords = this.config.abuseKeywords.filter(keyword =>
+            normalizedMessage.includes(keyword.toLowerCase()),
+        );
+
+        if (matchedKeywords.length > 0) {
+            const moderationSignal: ModerationReviewRequestedEvent = {
+                type: 'moderation.review.requested',
+                subjectUri: conversationUri,
+                reason: `abuse-keyword:${matchedKeywords.join(',')}`,
+                requestedAt: sentAt,
+            };
+
+            this.moderationSignals.push(moderationSignal);
+            return {
+                allowed: true,
+                code: 'ABUSE_FLAGGED',
+                userMessage:
+                    'Message sent, but flagged for safety review due to policy keywords.',
+                matchedKeywords,
+                moderationSignal,
+            };
+        }
+
+        return {
+            allowed: true,
+            code: 'OK',
+            userMessage: 'Message sent.',
+            matchedKeywords: [],
+        };
+    }
+
+    reportAbuse(input: ReportAbuseInput): {
+        reportRecord: ModerationReportRecord;
+        moderationSignal: ModerationReviewRequestedEvent;
+    } {
+        const subjectUri = atUriSchema.parse(input.subjectUri);
+        const reporterDid = didSchema.parse(input.reporterDid);
+        const createdAt = isoDateTimeSchema.parse(
+            input.createdAt ?? new Date().toISOString(),
+        );
+
+        const recordCandidate = {
+            $type: recordNsid.moderationReport,
+            version: '1.0.0',
+            subjectUri,
+            reporterDid,
+            reason: input.reason,
+            details: input.details?.trim() || undefined,
+            createdAt,
+        } satisfies ModerationReportRecord;
+
+        const reportRecord = validateRecordPayload(
+            recordNsid.moderationReport,
+            recordCandidate,
+        );
+
+        const moderationSignal: ModerationReviewRequestedEvent = {
+            type: 'moderation.review.requested',
+            subjectUri,
+            reason: `user-report:${reportRecord.reason}`,
+            requestedAt: createdAt,
+        };
+
+        this.moderationSignals.push(moderationSignal);
+        return { reportRecord, moderationSignal };
+    }
+
+    drainModerationSignals(): ModerationReviewRequestedEvent[] {
+        const signals = [...this.moderationSignals].map(signal => clone(signal));
+        this.moderationSignals.length = 0;
+        return signals;
+    }
+}
+
+export interface RoutingFixture {
+    id: string;
+    input: RoutingAssistantInput;
+    expectedRule: RoutingDecision['matchedRule'];
+    expectedDestinationKind: RoutingDecision['destinationKind'];
+}
+
+export const buildPhase5RoutingFixtures = (): readonly RoutingFixture[] => {
+    return [
+        {
+            id: 'post-author-direct',
+            input: {
+                aidPostUri:
+                    'at://did:example:requester/app.mutualhub.aid.post/post-author-1',
+                requesterDid: 'did:example:requester',
+                aidCategory: 'food',
+                urgency: 'high',
+                postAuthorDid: 'did:example:author',
+                volunteerCandidates: [],
+                resourceCandidates: [],
+                now: '2026-02-26T14:00:00.000Z',
+            },
+            expectedRule: 'RULE_POST_AUTHOR',
+            expectedDestinationKind: 'post-author',
+        },
+        {
+            id: 'volunteer-best-match',
+            input: {
+                aidPostUri:
+                    'at://did:example:requester/app.mutualhub.aid.post/volunteer-1',
+                requesterDid: 'did:example:requester',
+                aidCategory: 'transport',
+                urgency: 'critical',
+                volunteerCandidates: [
+                    {
+                        id: 'v2',
+                        did: 'did:example:volunteer-b',
+                        availability: 'within-24h',
+                        trustScore: 0.95,
+                        matchesCategory: true,
+                    },
+                    {
+                        id: 'v1',
+                        did: 'did:example:volunteer-a',
+                        availability: 'immediate',
+                        trustScore: 0.8,
+                        matchesCategory: true,
+                    },
+                ],
+                resourceCandidates: [],
+                now: '2026-02-26T14:05:00.000Z',
+            },
+            expectedRule: 'RULE_VOLUNTEER_POOL',
+            expectedDestinationKind: 'volunteer-pool',
+        },
+        {
+            id: 'resource-verified',
+            input: {
+                aidPostUri:
+                    'at://did:example:requester/app.mutualhub.aid.post/resource-1',
+                requesterDid: 'did:example:requester',
+                aidCategory: 'medical',
+                urgency: 'medium',
+                volunteerCandidates: [
+                    {
+                        id: 'v3',
+                        did: 'did:example:volunteer-c',
+                        availability: 'unavailable',
+                        trustScore: 0.6,
+                        matchesCategory: false,
+                    },
+                ],
+                resourceCandidates: [
+                    {
+                        id: 'r2',
+                        verificationStatus: 'community-verified',
+                        supportsCategory: true,
+                        currentlyOpen: true,
+                    },
+                    {
+                        id: 'r1',
+                        verificationStatus: 'partner-verified',
+                        supportsCategory: true,
+                        currentlyOpen: true,
+                    },
+                ],
+                now: '2026-02-26T14:10:00.000Z',
+            },
+            expectedRule: 'RULE_VERIFIED_RESOURCE',
+            expectedDestinationKind: 'verified-resource',
+        },
+    ] as const;
+};

--- a/services/api/src/chat-service.ts
+++ b/services/api/src/chat-service.ts
@@ -1,0 +1,404 @@
+import { ZodError } from 'zod';
+import {
+    ChatFlowError,
+    ChatSafetyControls,
+    ConversationMetadataStore,
+    DeterministicRoutingAssistant,
+    buildPhase5RoutingFixtures,
+    createPostLinkedChatContext,
+    type AidPostRecord,
+    type ChatInitiationSurface,
+    type RecipientTransportCapability,
+} from '@mutual-hub/shared';
+
+export interface ApiChatRouteResult {
+    statusCode: number;
+    body: unknown;
+}
+
+interface ApiChatErrorResponse {
+    error: {
+        code:
+            | 'INVALID_QUERY'
+            | 'UNAUTHORIZED'
+            | 'INVALID_CONTEXT'
+            | 'UNSUPPORTED_SCENARIO';
+        message: string;
+        details?: Record<string, unknown>;
+    };
+}
+
+const readString = (
+    params: URLSearchParams,
+    key: string,
+): string | undefined => {
+    const value = params.get(key);
+    if (value === null || value.trim() === '') {
+        return undefined;
+    }
+
+    return value;
+};
+
+const requireString = (
+    params: URLSearchParams,
+    key: string,
+): string => {
+    const value = readString(params, key);
+    if (!value) {
+        throw new ChatFlowError('INVALID_CONTEXT', `Missing required field: ${key}`);
+    }
+
+    return value;
+};
+
+const parseInitiationSurface = (
+    value: string | undefined,
+): ChatInitiationSurface => {
+    if (value === 'map' || value === 'feed' || value === 'detail') {
+        return value;
+    }
+
+    return 'detail';
+};
+
+const parseAidCategory = (
+    value: string | undefined,
+): AidPostRecord['category'] => {
+    if (
+        value === 'food' ||
+        value === 'shelter' ||
+        value === 'medical' ||
+        value === 'transport' ||
+        value === 'childcare' ||
+        value === 'other'
+    ) {
+        return value;
+    }
+
+    return 'other';
+};
+
+const parseUrgency = (value: string | undefined): AidPostRecord['urgency'] => {
+    if (
+        value === 'low' ||
+        value === 'medium' ||
+        value === 'high' ||
+        value === 'critical'
+    ) {
+        return value;
+    }
+
+    return 'medium';
+};
+
+const toErrorResult = (
+    error: unknown,
+    fallbackMessage: string,
+): ApiChatRouteResult => {
+    if (error instanceof ChatFlowError) {
+        const code: ApiChatErrorResponse['error']['code'] =
+            error.code === 'UNAUTHORIZED' ?
+                'UNAUTHORIZED'
+            : error.code === 'INVALID_CONTEXT' ?
+                'INVALID_CONTEXT'
+            :   'INVALID_QUERY';
+
+        return {
+            statusCode: code === 'UNAUTHORIZED' ? 403 : 400,
+            body: {
+                error: {
+                    code,
+                    message: error.message,
+                    details: error.details,
+                },
+            } satisfies ApiChatErrorResponse,
+        };
+    }
+
+    if (error instanceof ZodError) {
+        return {
+            statusCode: 400,
+            body: {
+                error: {
+                    code: 'INVALID_QUERY',
+                    message: 'Input validation failed.',
+                    details: {
+                        issues: error.issues.map(issue => ({
+                            path: issue.path.join('.'),
+                            message: issue.message,
+                        })),
+                    },
+                },
+            } satisfies ApiChatErrorResponse,
+        };
+    }
+
+    return {
+        statusCode: 400,
+        body: {
+            error: {
+                code: 'INVALID_QUERY',
+                message: fallbackMessage,
+            },
+        } satisfies ApiChatErrorResponse,
+    };
+};
+
+const fixtureCapabilities = new Map<string, RecipientTransportCapability>([
+    [
+        'did:example:alice',
+        {
+            recipientDid: 'did:example:alice',
+            supportsAtprotoChat: true,
+            fallbackChannels: ['manual-review'],
+            detectedAt: '2026-02-26T16:00:00.000Z',
+        },
+    ],
+    [
+        'did:example:resource-fallback',
+        {
+            recipientDid: 'did:example:resource-fallback',
+            supportsAtprotoChat: false,
+            fallbackChannels: ['url', 'manual-review'],
+            detectedAt: '2026-02-26T16:00:00.000Z',
+        },
+    ],
+]);
+
+export class ApiChatService {
+    private readonly routingAssistant = new DeterministicRoutingAssistant();
+    private readonly metadataStore = new ConversationMetadataStore();
+    private readonly safetyControls = new ChatSafetyControls();
+
+    initiateFromParams(params: URLSearchParams): ApiChatRouteResult {
+        try {
+            const initiatedByDid = requireString(params, 'initiatedByDid');
+            const recipientDid = requireString(params, 'recipientDid');
+            const aidPostUri = requireString(params, 'aidPostUri');
+            const initiatedFrom = parseInitiationSurface(
+                readString(params, 'initiatedFrom'),
+            );
+
+            const allowInitiation = readString(params, 'allowInitiation') !== 'false';
+            const allowedParticipants = readString(params, 'allowedParticipants')
+                ?.split(',')
+                .map(value => value.trim())
+                .filter(Boolean);
+
+            const chat = createPostLinkedChatContext({
+                aidPostUri,
+                initiatedByDid,
+                recipientDid,
+                initiatedFrom,
+                allowInitiation,
+                allowedParticipantDids: allowedParticipants,
+                now: readString(params, 'now'),
+            });
+
+            const routing = this.routingAssistant.decide({
+                aidPostUri,
+                requesterDid: initiatedByDid,
+                aidCategory: parseAidCategory(readString(params, 'category')),
+                urgency: parseUrgency(readString(params, 'urgency')),
+                postAuthorDid: recipientDid,
+                volunteerCandidates: [],
+                resourceCandidates: [],
+                now: readString(params, 'now'),
+            });
+
+            const existing = this.metadataStore.getConversation(chat.conversationUri);
+            const persisted = this.metadataStore.upsertConversation({
+                chat,
+                routingDecision: routing,
+                recipientCapability: this.resolveCapability(
+                    recipientDid,
+                    readString(params, 'supportsAtprotoChat'),
+                    readString(params, 'now'),
+                ),
+                updatedAt: readString(params, 'now'),
+            });
+
+            return {
+                statusCode: 200,
+                body: {
+                    conversationUri: persisted.conversationUri,
+                    created: existing === null,
+                    transportPath: persisted.transportPath,
+                    fallbackNotice: persisted.fallbackNotice,
+                    requestContext: persisted.requestContext,
+                },
+            };
+        } catch (error) {
+            return toErrorResult(error, 'Failed to initiate chat conversation.');
+        }
+    }
+
+    routeScenarioFromParams(params: URLSearchParams): ApiChatRouteResult {
+        const scenario = readString(params, 'scenario') ?? 'post-author-direct';
+        const fixture = buildPhase5RoutingFixtures().find(item => item.id === scenario);
+
+        if (!fixture) {
+            return {
+                statusCode: 400,
+                body: {
+                    error: {
+                        code: 'UNSUPPORTED_SCENARIO',
+                        message: `Unsupported routing scenario: ${scenario}`,
+                    },
+                } satisfies ApiChatErrorResponse,
+            };
+        }
+
+        const decision = this.routingAssistant.decide(fixture.input);
+        return {
+            statusCode: 200,
+            body: {
+                scenario,
+                decision,
+            },
+        };
+    }
+
+    listConversationsFromParams(params: URLSearchParams): ApiChatRouteResult {
+        try {
+            const aidPostUri = requireString(params, 'aidPostUri');
+            const conversations = this.metadataStore.listForAidPost(aidPostUri);
+
+            return {
+                statusCode: 200,
+                body: {
+                    total: conversations.length,
+                    results: conversations,
+                },
+            };
+        } catch (error) {
+            return toErrorResult(error, 'Failed to list conversation metadata.');
+        }
+    }
+
+    evaluateSafetyFromParams(params: URLSearchParams): ApiChatRouteResult {
+        try {
+            const result = this.safetyControls.evaluateOutboundMessage({
+                senderDid: requireString(params, 'senderDid'),
+                recipientDid: requireString(params, 'recipientDid'),
+                conversationUri: requireString(params, 'conversationUri'),
+                message: requireString(params, 'message'),
+                sentAt: readString(params, 'sentAt'),
+            });
+
+            return {
+                statusCode: 200,
+                body: result,
+            };
+        } catch (error) {
+            return toErrorResult(error, 'Failed to evaluate safety policy.');
+        }
+    }
+
+    blockFromParams(params: URLSearchParams): ApiChatRouteResult {
+        try {
+            const actorDid = requireString(params, 'actorDid');
+            const targetDid = requireString(params, 'targetDid');
+            this.safetyControls.blockParticipant(actorDid, targetDid);
+            return {
+                statusCode: 200,
+                body: {
+                    ok: true,
+                    action: 'block',
+                    actorDid,
+                    targetDid,
+                },
+            };
+        } catch (error) {
+            return toErrorResult(error, 'Failed to block participant.');
+        }
+    }
+
+    muteFromParams(params: URLSearchParams): ApiChatRouteResult {
+        try {
+            const actorDid = requireString(params, 'actorDid');
+            const conversationUri = requireString(params, 'conversationUri');
+            this.safetyControls.muteConversation(actorDid, conversationUri);
+            return {
+                statusCode: 200,
+                body: {
+                    ok: true,
+                    action: 'mute',
+                    actorDid,
+                    conversationUri,
+                },
+            };
+        } catch (error) {
+            return toErrorResult(error, 'Failed to mute conversation.');
+        }
+    }
+
+    reportFromParams(params: URLSearchParams): ApiChatRouteResult {
+        try {
+            const result = this.safetyControls.reportAbuse({
+                subjectUri: requireString(params, 'subjectUri'),
+                reporterDid: requireString(params, 'reporterDid'),
+                reason:
+                    (readString(params, 'reason') as
+                        | 'spam'
+                        | 'abuse'
+                        | 'fraud'
+                        | 'other'
+                        | undefined) ?? 'other',
+                details: readString(params, 'details'),
+                createdAt: readString(params, 'createdAt'),
+            });
+
+            return {
+                statusCode: 200,
+                body: result,
+            };
+        } catch (error) {
+            return toErrorResult(error, 'Failed to submit moderation report.');
+        }
+    }
+
+    drainModerationSignals(): ApiChatRouteResult {
+        return {
+            statusCode: 200,
+            body: {
+                total: this.safetyControls.drainModerationSignals().length,
+            },
+        };
+    }
+
+    private resolveCapability(
+        recipientDid: string,
+        explicitFlag: string | undefined,
+        now: string | undefined,
+    ): RecipientTransportCapability {
+        const fixture = fixtureCapabilities.get(recipientDid);
+        if (fixture) {
+            return {
+                ...fixture,
+                detectedAt: now ?? fixture.detectedAt,
+            };
+        }
+
+        if (explicitFlag === 'true' || explicitFlag === 'false') {
+            return {
+                recipientDid,
+                supportsAtprotoChat: explicitFlag === 'true',
+                fallbackChannels: ['manual-review'],
+                detectedAt: now ?? new Date().toISOString(),
+            };
+        }
+
+        return {
+            recipientDid,
+            supportsAtprotoChat: false,
+            fallbackChannels: ['manual-review'],
+            detectedAt: now ?? new Date().toISOString(),
+        };
+    }
+}
+
+export const createFixtureChatService = (): ApiChatService => {
+    return new ApiChatService();
+};

--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -6,10 +6,12 @@ import {
     loadApiConfig,
     type ServiceHealth,
 } from '@mutual-hub/shared';
+import { createFixtureChatService } from './chat-service.js';
 import { createFixtureQueryService } from './query-service.js';
 
 const config = loadApiConfig();
 const queryService = createFixtureQueryService();
+const chatService = createFixtureChatService();
 
 const healthPayload: ServiceHealth = {
     service: 'api',
@@ -43,6 +45,14 @@ export const createApiServer = () => {
                     '/query/map',
                     '/query/feed',
                     '/query/directory',
+                    '/chat/initiate',
+                    '/chat/route',
+                    '/chat/conversations',
+                    '/chat/safety/evaluate',
+                    '/chat/safety/block',
+                    '/chat/safety/mute',
+                    '/chat/safety/report',
+                    '/chat/safety/signals/drain',
                     '/health',
                 ],
             });
@@ -63,6 +73,60 @@ export const createApiServer = () => {
 
         if (requestUrl.pathname === '/query/directory') {
             const result = queryService.queryDirectory(requestUrl.searchParams);
+            writeJson(response, result.statusCode, result.body);
+            return;
+        }
+
+        if (requestUrl.pathname === '/chat/initiate') {
+            const result = chatService.initiateFromParams(requestUrl.searchParams);
+            writeJson(response, result.statusCode, result.body);
+            return;
+        }
+
+        if (requestUrl.pathname === '/chat/route') {
+            const result = chatService.routeScenarioFromParams(
+                requestUrl.searchParams,
+            );
+            writeJson(response, result.statusCode, result.body);
+            return;
+        }
+
+        if (requestUrl.pathname === '/chat/conversations') {
+            const result = chatService.listConversationsFromParams(
+                requestUrl.searchParams,
+            );
+            writeJson(response, result.statusCode, result.body);
+            return;
+        }
+
+        if (requestUrl.pathname === '/chat/safety/evaluate') {
+            const result = chatService.evaluateSafetyFromParams(
+                requestUrl.searchParams,
+            );
+            writeJson(response, result.statusCode, result.body);
+            return;
+        }
+
+        if (requestUrl.pathname === '/chat/safety/block') {
+            const result = chatService.blockFromParams(requestUrl.searchParams);
+            writeJson(response, result.statusCode, result.body);
+            return;
+        }
+
+        if (requestUrl.pathname === '/chat/safety/mute') {
+            const result = chatService.muteFromParams(requestUrl.searchParams);
+            writeJson(response, result.statusCode, result.body);
+            return;
+        }
+
+        if (requestUrl.pathname === '/chat/safety/report') {
+            const result = chatService.reportFromParams(requestUrl.searchParams);
+            writeJson(response, result.statusCode, result.body);
+            return;
+        }
+
+        if (requestUrl.pathname === '/chat/safety/signals/drain') {
+            const result = chatService.drainModerationSignals();
             writeJson(response, result.statusCode, result.body);
             return;
         }

--- a/services/api/src/phase5.test.ts
+++ b/services/api/src/phase5.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from 'vitest';
+import { createFixtureChatService } from './chat-service.js';
+
+describe('api phase 5 chat service', () => {
+    it('initiates from map and feed into the same deterministic conversation context', () => {
+        const service = createFixtureChatService();
+
+        const mapResult = service.initiateFromParams(
+            new URLSearchParams({
+                aidPostUri:
+                    'at://did:example:alice/app.mutualhub.aid.post/post-5',
+                initiatedByDid: 'did:example:helper',
+                recipientDid: 'did:example:alice',
+                initiatedFrom: 'map',
+                now: '2026-02-26T16:10:00.000Z',
+            }),
+        );
+
+        const feedResult = service.initiateFromParams(
+            new URLSearchParams({
+                aidPostUri:
+                    'at://did:example:alice/app.mutualhub.aid.post/post-5',
+                initiatedByDid: 'did:example:helper',
+                recipientDid: 'did:example:alice',
+                initiatedFrom: 'feed',
+                now: '2026-02-26T16:11:00.000Z',
+            }),
+        );
+
+        expect(mapResult.statusCode).toBe(200);
+        expect(feedResult.statusCode).toBe(200);
+
+        const mapBody = mapResult.body as {
+            conversationUri: string;
+            created: boolean;
+        };
+        const feedBody = feedResult.body as {
+            conversationUri: string;
+            created: boolean;
+        };
+
+        expect(mapBody.created).toBe(true);
+        expect(feedBody.created).toBe(false);
+        expect(mapBody.conversationUri).toBe(feedBody.conversationUri);
+    });
+
+    it('returns unauthorized response when initiation permission fails', () => {
+        const service = createFixtureChatService();
+        const result = service.initiateFromParams(
+            new URLSearchParams({
+                aidPostUri:
+                    'at://did:example:alice/app.mutualhub.aid.post/post-6',
+                initiatedByDid: 'did:example:helper',
+                recipientDid: 'did:example:alice',
+                initiatedFrom: 'detail',
+                allowInitiation: 'false',
+            }),
+        );
+
+        expect(result.statusCode).toBe(403);
+        expect(result.body).toMatchObject({
+            error: {
+                code: 'UNAUTHORIZED',
+            },
+        });
+    });
+
+    it('returns deterministic routing decision for fixture scenario', () => {
+        const service = createFixtureChatService();
+        const result = service.routeScenarioFromParams(
+            new URLSearchParams({ scenario: 'volunteer-best-match' }),
+        );
+
+        expect(result.statusCode).toBe(200);
+        expect(result.body).toMatchObject({
+            decision: {
+                matchedRule: 'RULE_VOLUNTEER_POOL',
+                destinationKind: 'volunteer-pool',
+            },
+        });
+    });
+
+    it('exposes explicit fallback notice when recipient lacks AT-native capability', () => {
+        const service = createFixtureChatService();
+
+        const result = service.initiateFromParams(
+            new URLSearchParams({
+                aidPostUri:
+                    'at://did:example:resource-fallback/app.mutualhub.aid.post/post-7',
+                initiatedByDid: 'did:example:helper',
+                recipientDid: 'did:example:resource-fallback',
+                initiatedFrom: 'feed',
+                now: '2026-02-26T16:20:00.000Z',
+            }),
+        );
+
+        expect(result.statusCode).toBe(200);
+        expect(result.body).toMatchObject({
+            transportPath: 'manual-fallback',
+            fallbackNotice: {
+                code: 'RECIPIENT_CAPABILITY_MISSING',
+                safeForUser: true,
+            },
+        });
+    });
+
+    it('supports safety evaluate/block/mute/report flow', () => {
+        const service = createFixtureChatService();
+
+        const block = service.blockFromParams(
+            new URLSearchParams({
+                actorDid: 'did:example:alice',
+                targetDid: 'did:example:blocked',
+            }),
+        );
+        expect(block.statusCode).toBe(200);
+
+        const blocked = service.evaluateSafetyFromParams(
+            new URLSearchParams({
+                senderDid: 'did:example:blocked',
+                recipientDid: 'did:example:alice',
+                conversationUri:
+                    'at://did:example:alice/app.mutualhub.conversation.meta/conv-9',
+                message: 'Hello',
+                sentAt: '2026-02-26T16:30:00.000Z',
+            }),
+        );
+        expect(blocked.statusCode).toBe(200);
+        expect(blocked.body).toMatchObject({
+            code: 'BLOCKED',
+            allowed: false,
+        });
+
+        const report = service.reportFromParams(
+            new URLSearchParams({
+                subjectUri:
+                    'at://did:example:alice/app.mutualhub.conversation.meta/conv-9',
+                reporterDid: 'did:example:alice',
+                reason: 'abuse',
+                details: 'Escalate for review',
+                createdAt: '2026-02-26T16:31:00.000Z',
+            }),
+        );
+
+        expect(report.statusCode).toBe(200);
+        expect(report.body).toMatchObject({
+            reportRecord: {
+                reason: 'abuse',
+            },
+        });
+
+        const drained = service.drainModerationSignals();
+        expect(drained.statusCode).toBe(200);
+        expect(drained.body).toMatchObject({
+            total: 1,
+        });
+    });
+});

--- a/services/api/src/smoke.test.ts
+++ b/services/api/src/smoke.test.ts
@@ -3,6 +3,6 @@ import { CONTRACT_VERSION } from '@mutual-hub/shared';
 
 describe('api service shell', () => {
     it('references shared contracts', () => {
-        expect(CONTRACT_VERSION).toContain('phase3');
+        expect(CONTRACT_VERSION).toContain('phase5');
     });
 });

--- a/services/indexer/src/smoke.test.ts
+++ b/services/indexer/src/smoke.test.ts
@@ -3,6 +3,6 @@ import { CONTRACT_VERSION } from '@mutual-hub/shared';
 
 describe('indexer service shell', () => {
     it('references shared contracts', () => {
-        expect(CONTRACT_VERSION).toBe('0.3.0-phase3');
+        expect(CONTRACT_VERSION).toBe('0.5.0-phase5');
     });
 });


### PR DESCRIPTION
## Summary
- implement Phase 5 shared messaging domain (post-linked chat init, deterministic routing, metadata fallback, safety controls)
- add API chat service/routes and Phase 5 API tests
- add web chat UX state/test module and update docs/readme/contracts to Phase 5 baseline
- keep full workspace quality gates green

## Verification
- npm run check

## Roadmap / issue linkage
- Refs #41
- Closes #26
- Closes #25
- Closes #31
- Closes #28