### PR TITLE
feat: execute roadmap Phase 6 directory + volunteer onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Mutual Hub (Phase 5 Baseline)
+# Mutual Hub (Phase 6 Baseline)
 
-This repository is scaffolded through **Phase 5** of roadmap issue #41.
+This repository is scaffolded through **Phase 6** of roadmap issue #41.
 
 ## Stack
 
@@ -40,6 +40,13 @@ This repository is scaffolded through **Phase 5** of roadmap issue #41.
 - Conversation metadata persistence with recipient-capability fallback notices.
 - Chat safety controls: block/mute/report, abuse keyword flagging, and rate limits.
 
+## Phase 6 additions
+
+- Resource directory operational metadata ingestion/indexing (location overlays, open hours, eligibility notes).
+- Resource directory UX logic for overlays, detail panel actions, and accessible loading/empty/error states.
+- Volunteer onboarding/profile management domain with validation and checkpoint tracking.
+- Preference-aware volunteer routing inputs integrated into deterministic routing decisions.
+
 ## Service boundaries
 
 - **API service**: request/response boundary for web clients and downstream contracts.
@@ -57,6 +64,7 @@ Detailed domain and boundary docs:
 - `docs/at-protocol/tombstone-contract.md`
 - `docs/architecture/phase3-ingestion-query.md`
 - `docs/architecture/phase5-chat-routing.md`
+- `docs/architecture/phase6-directory-onboarding.md`
 
 ## Local setup
 
@@ -79,7 +87,7 @@ Each backend service exposes a health endpoint:
 - Indexer: `GET http://localhost:4100/health`
 - Moderation worker: `GET http://localhost:4200/health`
 
-Phase 5 service endpoints:
+Phase 6 service endpoints:
 
 - API:
     - `GET /query/map`
@@ -93,6 +101,9 @@ Phase 5 service endpoints:
     - `GET /chat/safety/mute`
     - `GET /chat/safety/report`
     - `GET /chat/safety/signals/drain`
+    - `GET /chat/route/preference-aware`
+    - `GET /volunteer/profile/upsert`
+    - `GET /volunteer/profiles`
 - Indexer:
     - `GET /ingestion/metrics`
     - `GET /ingestion/logs`

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -14,14 +14,14 @@ export const App = () => {
                 <h1 className='font-heading text-4xl font-black uppercase'>
                     {APP_TITLE}
                 </h1>
-                <Badge tone='danger'>Phase 5 baseline</Badge>
+                <Badge tone='danger'>Phase 6 baseline</Badge>
             </header>
 
             <div className='grid gap-6 md:grid-cols-2'>
                 <Panel title='Discovery shell'>
                     <p className='mb-3 text-sm text-[var(--mh-text-muted)]'>
                         Vite + React + TypeScript + Tailwind are wired and ready
-                        for Phase 5 chat triage and routing.
+                        for Phase 6 directory overlays and volunteer onboarding.
                     </p>
                     <label className='mb-2 block text-xs font-bold uppercase tracking-wide'>
                         Search requests

--- a/apps/web/src/index.ts
+++ b/apps/web/src/index.ts
@@ -5,3 +5,5 @@ export * from './discovery-primitives.js';
 export * from './feed-ux.js';
 export * from './map-ux.js';
 export * from './posting-form.js';
+export * from './resource-directory-ux.js';
+export * from './volunteer-onboarding.js';

--- a/apps/web/src/resource-directory-ux.test.ts
+++ b/apps/web/src/resource-directory-ux.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+import { defaultDiscoveryFilterState } from './discovery-filters.js';
+import {
+    buildResourceOverlayViewModel,
+    openResourceDetailPanel,
+    resolveResourceDirectoryUiState,
+    type ResourceDirectoryCard,
+} from './resource-directory-ux.js';
+
+const buildResource = (
+    overrides: Partial<ResourceDirectoryCard> = {},
+): ResourceDirectoryCard => {
+    return {
+        uri: 'at://did:example:org/app.mutualhub.directory.resource/resource-1',
+        id: 'resource-1',
+        name: 'Neighborhood Clinic',
+        category: 'clinic',
+        location: {
+            lat: 1.3001,
+            lng: 103.8001,
+            precisionMeters: 200,
+            areaLabel: 'Central',
+        },
+        openHours: 'Walk-in evenings',
+        eligibilityNotes: 'No insurance required',
+        contact: {
+            phone: '+1-555-0100',
+        },
+        ...overrides,
+    };
+};
+
+describe('phase 6 resource directory overlays + details ui', () => {
+    it('updates overlays by shared discovery filters and category selection', () => {
+        const cards: ResourceDirectoryCard[] = [
+            buildResource({
+                uri: 'at://did:example:a/app.mutualhub.directory.resource/clinic-1',
+                id: 'clinic-1',
+                name: 'Central Clinic',
+                category: 'clinic',
+            }),
+            buildResource({
+                uri: 'at://did:example:b/app.mutualhub.directory.resource/food-1',
+                id: 'food-1',
+                name: 'Sunrise Food Bank',
+                category: 'food-bank',
+                openHours: 'Daily meal packs',
+                eligibilityNotes: 'Families prioritized',
+            }),
+            buildResource({
+                uri: 'at://did:example:c/app.mutualhub.directory.resource/shelter-1',
+                id: 'shelter-1',
+                name: 'Harbor Shelter',
+                category: 'shelter',
+                location: {
+                    lat: 1.39,
+                    lng: 103.89,
+                    precisionMeters: 300,
+                    areaLabel: 'Harbor',
+                },
+            }),
+        ];
+
+        const view = buildResourceOverlayViewModel(
+            cards,
+            {
+                ...defaultDiscoveryFilterState,
+                category: 'food',
+                text: 'meal',
+                center: { lat: 1.3, lng: 103.8 },
+                radiusMeters: 5000,
+            },
+            {
+                category: 'food-bank',
+            },
+        );
+
+        expect(view.cards).toHaveLength(1);
+        expect(view.cards[0]?.id).toBe('food-1');
+        expect(view.overlays).toHaveLength(1);
+        expect(view.overlays[0]?.radiusMeters).toBe(300);
+        expect(view.query.category).toBe('food');
+    });
+
+    it('shows hours and eligibility details in resource panel', () => {
+        const cards = [
+            buildResource({
+                uri: 'at://did:example:org/app.mutualhub.directory.resource/clinic-2',
+                id: 'clinic-2',
+                name: 'Northside Clinic',
+                openHours: 'Mon-Fri 18:00-22:00',
+                eligibilityNotes: 'Urgent care for walk-ins',
+            }),
+        ];
+
+        const detail = openResourceDetailPanel(cards, cards[0]!.uri);
+
+        expect(detail.open).toBe(true);
+        expect(detail.title).toBe('Northside Clinic');
+        expect(detail.openHours).toBe('Mon-Fri 18:00-22:00');
+        expect(detail.eligibilityNotes).toBe('Urgent care for walk-ins');
+        expect(
+            detail.actions.some(action => action.id === 'request_intake'),
+        ).toBe(true);
+    });
+
+    it('returns accessible loading/error/empty/ready ui states', () => {
+        const loading = resolveResourceDirectoryUiState({
+            loading: true,
+            resources: [],
+        });
+        expect(loading.status).toBe('loading');
+        expect(loading.ariaLiveMessage).toMatch(/Loading/i);
+
+        const error = resolveResourceDirectoryUiState({
+            loading: false,
+            errorMessage: 'Request timed out',
+            resources: [],
+        });
+        expect(error.status).toBe('error');
+        expect(error.ariaLiveMessage).toMatch(/failed to load/i);
+
+        const empty = resolveResourceDirectoryUiState({
+            loading: false,
+            resources: [],
+            activeCategoryFilter: 'clinic',
+        });
+        expect(empty.status).toBe('empty');
+        expect(empty.message).toMatch(/No resources found/i);
+
+        const ready = resolveResourceDirectoryUiState({
+            loading: false,
+            resources: [buildResource()],
+        });
+        expect(ready.status).toBe('ready');
+        expect(ready.ariaLiveMessage).toContain('1 directory resources loaded');
+    });
+});

--- a/apps/web/src/resource-directory-ux.ts
+++ b/apps/web/src/resource-directory-ux.ts
@@ -1,0 +1,338 @@
+import {
+    type AidCategory,
+    type DiscoveryFilterState,
+    type SharedAidDiscoveryQuery,
+    toMapDiscoveryQuery,
+} from './discovery-filters.js';
+
+const earthRadiusMeters = 6_371_000;
+const minimumOverlayPrecisionMeters = 300;
+
+export type DirectoryResourceCategory =
+    | 'food-bank'
+    | 'shelter'
+    | 'clinic'
+    | 'legal-aid'
+    | 'hotline'
+    | 'other';
+
+export interface ResourceDirectoryCard {
+    uri: string;
+    id: string;
+    name: string;
+    category: DirectoryResourceCategory;
+    location: {
+        lat: number;
+        lng: number;
+        precisionMeters: number;
+        areaLabel?: string;
+    };
+    openHours?: string;
+    eligibilityNotes?: string;
+    contact: {
+        url?: string;
+        phone?: string;
+    };
+    distanceMeters?: number;
+}
+
+export interface ResourceOverlayMarker {
+    uri: string;
+    id: string;
+    category: DirectoryResourceCategory;
+    lat: number;
+    lng: number;
+    radiusMeters: number;
+    label: string;
+}
+
+export interface ResourceOverlayFilters {
+    category?: DirectoryResourceCategory;
+}
+
+export interface ResourceOverlayViewModel {
+    query: SharedAidDiscoveryQuery;
+    cards: readonly ResourceDirectoryCard[];
+    overlays: readonly ResourceOverlayMarker[];
+    activeCategoryFilter?: DirectoryResourceCategory;
+}
+
+export interface ResourceDetailAction {
+    id: 'request_intake' | 'view_contact' | 'open_map';
+    label: string;
+    ariaLabel: string;
+}
+
+export interface ResourceDetailPanelModel {
+    open: boolean;
+    selectedUri?: string;
+    title?: string;
+    categoryLabel?: string;
+    openHours?: string;
+    eligibilityNotes?: string;
+    actions: readonly ResourceDetailAction[];
+}
+
+export type ResourceDirectoryUiState =
+    | {
+          status: 'loading';
+          message: string;
+          ariaLiveMessage: string;
+      }
+    | {
+          status: 'error';
+          message: string;
+          ariaLiveMessage: string;
+      }
+    | {
+          status: 'empty';
+          message: string;
+          ariaLiveMessage: string;
+      }
+    | {
+          status: 'ready';
+          message: string;
+          ariaLiveMessage: string;
+      };
+
+const toRadians = (value: number): number => (value * Math.PI) / 180;
+
+const haversineDistanceMeters = (
+    from: { lat: number; lng: number },
+    to: { lat: number; lng: number },
+): number => {
+    const latDelta = toRadians(to.lat - from.lat);
+    const lngDelta = toRadians(to.lng - from.lng);
+    const fromLat = toRadians(from.lat);
+    const toLat = toRadians(to.lat);
+
+    const a =
+        Math.sin(latDelta / 2) * Math.sin(latDelta / 2) +
+        Math.cos(fromLat) *
+            Math.cos(toLat) *
+            Math.sin(lngDelta / 2) *
+            Math.sin(lngDelta / 2);
+
+    return 2 * earthRadiusMeters * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+};
+
+const categoryToDirectoryCategories = (
+    category: AidCategory | undefined,
+): DirectoryResourceCategory[] => {
+    if (!category) {
+        return [];
+    }
+
+    if (category === 'food') {
+        return ['food-bank'];
+    }
+    if (category === 'shelter') {
+        return ['shelter'];
+    }
+    if (category === 'medical') {
+        return ['clinic'];
+    }
+
+    return [];
+};
+
+const resourceMatchesText = (
+    resource: ResourceDirectoryCard,
+    text: string,
+): boolean => {
+    const haystack = [
+        resource.name,
+        resource.openHours ?? '',
+        resource.eligibilityNotes ?? '',
+        resource.location.areaLabel ?? '',
+    ]
+        .join(' ')
+        .toLowerCase();
+
+    return haystack.includes(text.toLowerCase());
+};
+
+const toOverlayMarker = (
+    resource: ResourceDirectoryCard,
+): ResourceOverlayMarker => {
+    const precisionMeters = Math.max(
+        minimumOverlayPrecisionMeters,
+        Math.round(resource.location.precisionMeters),
+    );
+
+    return {
+        uri: resource.uri,
+        id: resource.id,
+        category: resource.category,
+        lat: Number(resource.location.lat.toFixed(6)),
+        lng: Number(resource.location.lng.toFixed(6)),
+        radiusMeters: precisionMeters,
+        label: resource.location.areaLabel ?? resource.name,
+    };
+};
+
+const toCategoryLabel = (category: DirectoryResourceCategory): string => {
+    if (category === 'food-bank') {
+        return 'Food bank';
+    }
+    if (category === 'legal-aid') {
+        return 'Legal aid';
+    }
+    return category.charAt(0).toUpperCase() + category.slice(1);
+};
+
+export const filterResourceDirectoryCards = (
+    cards: readonly ResourceDirectoryCard[],
+    state: DiscoveryFilterState,
+    filters: ResourceOverlayFilters = {},
+): ResourceDirectoryCard[] => {
+    const query = toMapDiscoveryQuery(state);
+    const categoryFilters = categoryToDirectoryCategories(state.category);
+
+    return cards
+        .filter(card => {
+            if (filters.category && card.category !== filters.category) {
+                return false;
+            }
+
+            if (
+                categoryFilters.length > 0 &&
+                !categoryFilters.includes(card.category)
+            ) {
+                return false;
+            }
+
+            if (query.text && !resourceMatchesText(card, query.text)) {
+                return false;
+            }
+
+            if (query.center && query.radiusMeters !== undefined) {
+                const distance = haversineDistanceMeters(
+                    query.center,
+                    card.location,
+                );
+                if (distance > query.radiusMeters) {
+                    return false;
+                }
+            }
+
+            return true;
+        })
+        .sort((left, right) => {
+            if (
+                left.distanceMeters !== undefined &&
+                right.distanceMeters !== undefined &&
+                left.distanceMeters !== right.distanceMeters
+            ) {
+                return left.distanceMeters - right.distanceMeters;
+            }
+
+            return left.name.localeCompare(right.name);
+        });
+};
+
+export const buildResourceOverlayViewModel = (
+    cards: readonly ResourceDirectoryCard[],
+    state: DiscoveryFilterState,
+    filters: ResourceOverlayFilters = {},
+): ResourceOverlayViewModel => {
+    const query = toMapDiscoveryQuery(state);
+    const filtered = filterResourceDirectoryCards(cards, state, filters);
+
+    return {
+        query,
+        cards: filtered,
+        overlays: filtered.map(card => toOverlayMarker(card)),
+        activeCategoryFilter: filters.category,
+    };
+};
+
+export const openResourceDetailPanel = (
+    cards: readonly ResourceDirectoryCard[],
+    selectedUri: string,
+): ResourceDetailPanelModel => {
+    const selected = cards.find(card => card.uri === selectedUri);
+    if (!selected) {
+        return {
+            open: false,
+            actions: [],
+        };
+    }
+
+    return {
+        open: true,
+        selectedUri,
+        title: selected.name,
+        categoryLabel: toCategoryLabel(selected.category),
+        openHours: selected.openHours ?? 'Hours unavailable',
+        eligibilityNotes:
+            selected.eligibilityNotes ?? 'Eligibility details unavailable',
+        actions: [
+            {
+                id: 'request_intake',
+                label: 'Request intake',
+                ariaLabel: `Request intake from ${selected.name}`,
+            },
+            {
+                id: 'view_contact',
+                label: 'View contact info',
+                ariaLabel: `View contact info for ${selected.name}`,
+            },
+            {
+                id: 'open_map',
+                label: 'Open map directions',
+                ariaLabel: `Open map directions to ${selected.name}`,
+            },
+        ],
+    };
+};
+
+export const closeResourceDetailPanel = (): ResourceDetailPanelModel => {
+    return {
+        open: false,
+        actions: [],
+    };
+};
+
+export const resolveResourceDirectoryUiState = (params: {
+    loading: boolean;
+    errorMessage?: string;
+    resources: readonly ResourceDirectoryCard[];
+    activeCategoryFilter?: DirectoryResourceCategory;
+}): ResourceDirectoryUiState => {
+    if (params.loading) {
+        return {
+            status: 'loading',
+            message: 'Loading directory resources…',
+            ariaLiveMessage: 'Loading resource directory results.',
+        };
+    }
+
+    if (params.errorMessage) {
+        return {
+            status: 'error',
+            message: params.errorMessage,
+            ariaLiveMessage:
+                'Resource directory failed to load. Please retry or adjust filters.',
+        };
+    }
+
+    if (params.resources.length === 0) {
+        const reason =
+            params.activeCategoryFilter ?
+                ` for ${toCategoryLabel(params.activeCategoryFilter)}`
+            :   '';
+
+        return {
+            status: 'empty',
+            message: `No resources found${reason}.`,
+            ariaLiveMessage: `No resources match current filters${reason}.`,
+        };
+    }
+
+    return {
+        status: 'ready',
+        message: `${params.resources.length} resources available.`,
+        ariaLiveMessage: `${params.resources.length} directory resources loaded.`,
+    };
+};

--- a/apps/web/src/volunteer-onboarding.test.ts
+++ b/apps/web/src/volunteer-onboarding.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import {
+    buildVolunteerProfileCreatePayload,
+    buildVolunteerProfileEditPayload,
+    isVolunteerFullyVerified,
+    summarizeCheckpoints,
+    toVolunteerOnboardingDraftFromRecord,
+    validateVolunteerOnboardingDraft,
+    type VolunteerOnboardingDraft,
+} from './volunteer-onboarding.js';
+
+const baseDraft: VolunteerOnboardingDraft = {
+    did: 'did:example:volunteer123',
+    displayName: 'Ari',
+    capabilities: ['transport', 'food-delivery'],
+    availability: 'within-24h',
+    contactPreference: 'chat-or-call',
+    skills: ['First aid', 'Meal delivery'],
+    availabilityWindows: ['weekday_evenings', 'weekend_mornings'],
+    preferredCategories: ['medical', 'food'],
+    preferredUrgencies: ['high', 'critical'],
+    maxDistanceKm: 15,
+    acceptsLateNight: true,
+    checkpoints: {
+        identityCheck: 'approved',
+        safetyTraining: 'approved',
+        communityReference: 'pending',
+    },
+};
+
+describe('phase 6 volunteer onboarding web ux', () => {
+    it('builds create payloads with skills/availability/checkpoint metadata', () => {
+        const payload = buildVolunteerProfileCreatePayload(baseDraft, {
+            now: '2026-02-26T08:30:00.000Z',
+        });
+
+        expect(payload.record.skills).toEqual(['First aid', 'Meal delivery']);
+        expect(payload.record.availabilityWindows).toEqual([
+            'weekday_evenings',
+            'weekend_mornings',
+        ]);
+        expect(payload.record.createdAt).toBe('2026-02-26T08:30:00.000Z');
+        expect(payload.checkpointSummary).toEqual({
+            approved: 2,
+            pending: 1,
+            rejected: 0,
+        });
+        expect(isVolunteerFullyVerified(baseDraft.checkpoints)).toBe(false);
+    });
+
+    it('supports edit payloads while preserving createdAt', () => {
+        const created = buildVolunteerProfileCreatePayload(baseDraft, {
+            now: '2026-02-26T09:00:00.000Z',
+        });
+
+        const edited = buildVolunteerProfileEditPayload(
+            created.record,
+            {
+                ...baseDraft,
+                displayName: 'Ari N.',
+                checkpoints: {
+                    identityCheck: 'approved',
+                    safetyTraining: 'approved',
+                    communityReference: 'approved',
+                },
+            },
+            { updatedAt: '2026-02-26T10:00:00.000Z' },
+        );
+
+        expect(edited.record.displayName).toBe('Ari N.');
+        expect(edited.record.createdAt).toBe('2026-02-26T09:00:00.000Z');
+        expect(edited.record.updatedAt).toBe('2026-02-26T10:00:00.000Z');
+        expect(edited.checkpointSummary.approved).toBe(3);
+    });
+
+    it('validates incomplete onboarding drafts', () => {
+        const result = validateVolunteerOnboardingDraft({
+            ...baseDraft,
+            did: 'invalid-did',
+            displayName: '',
+            capabilities: [],
+            skills: [],
+            availabilityWindows: [],
+            preferredCategories: [],
+            preferredUrgencies: [],
+            maxDistanceKm: 0,
+        });
+
+        expect(result.ok).toBe(false);
+        expect(result.errors.length).toBeGreaterThan(0);
+    });
+
+    it('summarizes checkpoint states and restores draft from record', () => {
+        const payload = buildVolunteerProfileCreatePayload(baseDraft);
+        const draft = toVolunteerOnboardingDraftFromRecord(payload.record);
+        const summary = summarizeCheckpoints(baseDraft.checkpoints);
+
+        expect(draft.skills).toEqual(baseDraft.skills);
+        expect(summary).toEqual({ approved: 2, pending: 1, rejected: 0 });
+    });
+});

--- a/apps/web/src/volunteer-onboarding.ts
+++ b/apps/web/src/volunteer-onboarding.ts
@@ -1,0 +1,268 @@
+import {
+    recordNsid,
+    type AidPostRecord,
+    type VolunteerProfileRecord,
+    validateRecordPayload,
+} from '@mutual-hub/at-lexicons';
+
+const didPattern = /^did:[a-z0-9:._%-]+$/i;
+
+export interface VolunteerVerificationCheckpoints {
+    identityCheck: 'pending' | 'approved' | 'rejected';
+    safetyTraining: 'pending' | 'approved' | 'rejected';
+    communityReference: 'pending' | 'approved' | 'rejected';
+}
+
+export interface VolunteerOnboardingDraft {
+    did: string;
+    displayName: string;
+    capabilities: VolunteerProfileRecord['capabilities'];
+    availability: VolunteerProfileRecord['availability'];
+    contactPreference: VolunteerProfileRecord['contactPreference'];
+    skills: string[];
+    availabilityWindows: string[];
+    preferredCategories: AidPostRecord['category'][];
+    preferredUrgencies: AidPostRecord['urgency'][];
+    maxDistanceKm: number;
+    acceptsLateNight: boolean;
+    checkpoints: VolunteerVerificationCheckpoints;
+    notes?: string;
+}
+
+export interface VolunteerOnboardingValidationIssue {
+    field:
+        | 'did'
+        | 'displayName'
+        | 'capabilities'
+        | 'skills'
+        | 'availabilityWindows'
+        | 'preferences';
+    message: string;
+}
+
+export interface VolunteerOnboardingValidationResult {
+    ok: boolean;
+    errors: readonly VolunteerOnboardingValidationIssue[];
+}
+
+export interface VolunteerCheckpointSummary {
+    approved: number;
+    pending: number;
+    rejected: number;
+}
+
+const normalizeTextList = (values: readonly string[]): string[] => {
+    const deduped = new Map<string, string>();
+
+    for (const rawValue of values) {
+        const value = rawValue.trim();
+        if (value.length === 0) {
+            continue;
+        }
+
+        const key = value.toLowerCase();
+        if (!deduped.has(key)) {
+            deduped.set(key, value);
+        }
+    }
+
+    return [...deduped.values()];
+};
+
+export const summarizeCheckpoints = (
+    checkpoints: VolunteerVerificationCheckpoints,
+): VolunteerCheckpointSummary => {
+    const statuses = Object.values(checkpoints);
+    return {
+        approved: statuses.filter(status => status === 'approved').length,
+        pending: statuses.filter(status => status === 'pending').length,
+        rejected: statuses.filter(status => status === 'rejected').length,
+    };
+};
+
+export const isVolunteerFullyVerified = (
+    checkpoints: VolunteerVerificationCheckpoints,
+): boolean => {
+    const summary = summarizeCheckpoints(checkpoints);
+    return summary.pending === 0 && summary.rejected === 0;
+};
+
+export const validateVolunteerOnboardingDraft = (
+    draft: VolunteerOnboardingDraft,
+): VolunteerOnboardingValidationResult => {
+    const errors: VolunteerOnboardingValidationIssue[] = [];
+
+    if (!didPattern.test(draft.did.trim())) {
+        errors.push({
+            field: 'did',
+            message: 'DID is required and must use a valid did:* format',
+        });
+    }
+
+    if (
+        draft.displayName.trim().length === 0 ||
+        draft.displayName.length > 80
+    ) {
+        errors.push({
+            field: 'displayName',
+            message: 'Display name is required and must be <= 80 characters',
+        });
+    }
+
+    if (draft.capabilities.length === 0) {
+        errors.push({
+            field: 'capabilities',
+            message: 'At least one capability is required',
+        });
+    }
+
+    if (normalizeTextList(draft.skills).length === 0) {
+        errors.push({
+            field: 'skills',
+            message: 'At least one skill is required',
+        });
+    }
+
+    if (normalizeTextList(draft.availabilityWindows).length === 0) {
+        errors.push({
+            field: 'availabilityWindows',
+            message: 'At least one availability window is required',
+        });
+    }
+
+    if (
+        draft.preferredCategories.length === 0 ||
+        draft.preferredUrgencies.length === 0 ||
+        draft.maxDistanceKm <= 0
+    ) {
+        errors.push({
+            field: 'preferences',
+            message:
+                'Preferred categories/urgencies and max distance are required',
+        });
+    }
+
+    return {
+        ok: errors.length === 0,
+        errors,
+    };
+};
+
+export const buildVolunteerProfileCreatePayload = (
+    draft: VolunteerOnboardingDraft,
+    options: { now?: string } = {},
+): {
+    record: VolunteerProfileRecord;
+    checkpointSummary: VolunteerCheckpointSummary;
+} => {
+    const validation = validateVolunteerOnboardingDraft(draft);
+    if (!validation.ok) {
+        throw new Error(
+            validation.errors.map(issue => issue.message).join('; '),
+        );
+    }
+
+    const now = options.now ?? new Date().toISOString();
+
+    const record = validateRecordPayload(recordNsid.volunteerProfile, {
+        $type: recordNsid.volunteerProfile,
+        version: '1.1.0',
+        displayName: draft.displayName.trim(),
+        capabilities: draft.capabilities,
+        availability: draft.availability,
+        contactPreference: draft.contactPreference,
+        skills: normalizeTextList(draft.skills),
+        availabilityWindows: normalizeTextList(draft.availabilityWindows),
+        verificationCheckpoints: draft.checkpoints,
+        matchingPreferences: {
+            preferredCategories: [...draft.preferredCategories],
+            preferredUrgencies: [...draft.preferredUrgencies],
+            maxDistanceKm: draft.maxDistanceKm,
+            acceptsLateNight: draft.acceptsLateNight,
+        },
+        notes: draft.notes?.trim() || undefined,
+        createdAt: now,
+        updatedAt: now,
+    });
+
+    return {
+        record,
+        checkpointSummary: summarizeCheckpoints(draft.checkpoints),
+    };
+};
+
+export const buildVolunteerProfileEditPayload = (
+    existingRecord: VolunteerProfileRecord,
+    draft: VolunteerOnboardingDraft,
+    options: { updatedAt?: string } = {},
+): {
+    record: VolunteerProfileRecord;
+    checkpointSummary: VolunteerCheckpointSummary;
+} => {
+    const validation = validateVolunteerOnboardingDraft(draft);
+    if (!validation.ok) {
+        throw new Error(
+            validation.errors.map(issue => issue.message).join('; '),
+        );
+    }
+
+    const updatedAt = options.updatedAt ?? new Date().toISOString();
+
+    const record = validateRecordPayload(recordNsid.volunteerProfile, {
+        $type: recordNsid.volunteerProfile,
+        version: '1.1.0',
+        displayName: draft.displayName.trim(),
+        capabilities: draft.capabilities,
+        availability: draft.availability,
+        contactPreference: draft.contactPreference,
+        skills: normalizeTextList(draft.skills),
+        availabilityWindows: normalizeTextList(draft.availabilityWindows),
+        verificationCheckpoints: draft.checkpoints,
+        matchingPreferences: {
+            preferredCategories: [...draft.preferredCategories],
+            preferredUrgencies: [...draft.preferredUrgencies],
+            maxDistanceKm: draft.maxDistanceKm,
+            acceptsLateNight: draft.acceptsLateNight,
+        },
+        notes: draft.notes?.trim() || undefined,
+        createdAt: existingRecord.createdAt,
+        updatedAt,
+    });
+
+    return {
+        record,
+        checkpointSummary: summarizeCheckpoints(draft.checkpoints),
+    };
+};
+
+export const toVolunteerOnboardingDraftFromRecord = (
+    record: VolunteerProfileRecord,
+    options: { did?: string } = {},
+): VolunteerOnboardingDraft => {
+    return {
+        did: options.did ?? 'did:example:placeholder',
+        displayName: record.displayName,
+        capabilities: [...record.capabilities],
+        availability: record.availability,
+        contactPreference: record.contactPreference,
+        skills: [...(record.skills ?? [])],
+        availabilityWindows: [...(record.availabilityWindows ?? [])],
+        preferredCategories: [
+            ...(record.matchingPreferences?.preferredCategories ?? ['other']),
+        ],
+        preferredUrgencies: [
+            ...(record.matchingPreferences?.preferredUrgencies ?? ['medium']),
+        ],
+        maxDistanceKm: record.matchingPreferences?.maxDistanceKm ?? 10,
+        acceptsLateNight: record.matchingPreferences?.acceptsLateNight ?? false,
+        checkpoints: {
+            identityCheck:
+                record.verificationCheckpoints?.identityCheck ?? 'pending',
+            safetyTraining:
+                record.verificationCheckpoints?.safetyTraining ?? 'pending',
+            communityReference:
+                record.verificationCheckpoints?.communityReference ?? 'pending',
+        },
+        notes: record.notes,
+    };
+};

--- a/docs/architecture/domain-map.md
+++ b/docs/architecture/domain-map.md
@@ -2,16 +2,16 @@
 
 This map defines bounded contexts, ownership, and primary interface boundaries for v1.
 
-| Domain               | Primary owner service              | Key records/interfaces                   | Notes                                                 |
-| -------------------- | ---------------------------------- | ---------------------------------------- | ----------------------------------------------------- |
-| Identity             | `services/api`                     | DID auth/session contracts               | Web clients only interact through API boundary        |
-| Aid records          | `services/api`, `services/indexer` | Query contracts + ingestion events       | API writes/query surface; indexer normalizes/searches |
-| Geo                  | `services/indexer`                 | Approximate-area and geo index contracts | No exact coordinate exposure in public APIs           |
-| Ranking              | `services/indexer`                 | Ranked feed/map response contracts       | Deterministic ranking pipeline boundary               |
-| Messaging            | `services/api`                     | 1:1 chat initiation/request contracts    | Moderation hooks via async events                     |
-| Moderation           | `services/moderation-worker`       | Moderation decision events               | Isolated async worker boundary                        |
-| Directory            | `services/indexer`                 | Resource directory index/query contracts | Consumed by API responses                             |
-| Volunteer onboarding | `services/api`                     | Volunteer profile contracts              | Future matching integration                           |
+| Domain               | Primary owner service              | Key records/interfaces                   | Notes                                                  |
+| -------------------- | ---------------------------------- | ---------------------------------------- | ------------------------------------------------------ |
+| Identity             | `services/api`                     | DID auth/session contracts               | Web clients only interact through API boundary         |
+| Aid records          | `services/api`, `services/indexer` | Query contracts + ingestion events       | API writes/query surface; indexer normalizes/searches  |
+| Geo                  | `services/indexer`                 | Approximate-area and geo index contracts | No exact coordinate exposure in public APIs            |
+| Ranking              | `services/indexer`                 | Ranked feed/map response contracts       | Deterministic ranking pipeline boundary                |
+| Messaging            | `services/api`                     | 1:1 chat initiation/request contracts    | Moderation hooks via async events                      |
+| Moderation           | `services/moderation-worker`       | Moderation decision events               | Isolated async worker boundary                         |
+| Directory            | `services/indexer`                 | Resource directory index/query contracts | Consumed by API responses                              |
+| Volunteer onboarding | `services/api`                     | Volunteer profile + preference contracts | Integrated into deterministic routing inputs (Phase 6) |
 
 ## Anti-corruption boundaries
 

--- a/docs/architecture/phase6-directory-onboarding.md
+++ b/docs/architecture/phase6-directory-onboarding.md
@@ -1,0 +1,78 @@
+# Phase 6 directory + volunteer onboarding (P6.1-P6.4)
+
+This document captures the Phase 6 implementation scope for roadmap issue #41.
+
+## Modules
+
+- Directory record schema + fixtures: `packages/at-lexicons/src/validators.ts`
+- Directory ingestion/normalization: `packages/shared/src/firehose.ts`
+- Directory indexing/query filters: `packages/shared/src/discovery.ts`
+- Volunteer onboarding domain store: `packages/shared/src/volunteer-onboarding.ts`
+- Preference-aware routing logic: `packages/shared/src/messaging.ts`
+- API volunteer/profile routes: `services/api/src/volunteer-service.ts`
+- Web resource UX logic: `apps/web/src/resource-directory-ux.ts`
+- Web volunteer onboarding logic: `apps/web/src/volunteer-onboarding.ts`
+
+## P6.1 directory record ingest/index
+
+Directory records now carry operational metadata for search and map overlays:
+
+- `location` (approximate lat/lng + precision)
+- `openHours`
+- `eligibilityNotes`
+- `operationalStatus`
+
+Ingestion normalizes these into directory payloads and searchable text. Query/index behavior supports:
+
+- category + verification status
+- operational status
+- optional geo radius filtering (lat/lng/radius)
+- deterministic create/update/delete lifecycle handling
+
+## P6.2 resource directory overlays + detail UX
+
+Resource directory UX logic provides:
+
+- overlay marker projection with minimum precision floor
+- shared discovery-filter integration (`text`, `category`, `radius`)
+- detail panel model with hours, eligibility, and accessible action labels
+- explicit loading/error/empty/ready UI states with aria-live messaging
+
+## P6.3 volunteer onboarding + profile management
+
+Volunteer onboarding flow validates and persists:
+
+- capabilities + availability
+- free-text skills + availability windows
+- verification checkpoint states
+- matching preferences (categories, urgencies, max distance, late-night flag)
+
+Profile upserts preserve deterministic metadata (`createdAt` on first write, `updatedAt` on changes).
+
+## P6.4 preference-aware routing inputs
+
+Volunteer preferences are transformed into routing candidates and fed into deterministic scoring.
+
+### Decision effects
+
+Preference signals influence volunteer routing by:
+
+- boosting category-preferred candidates
+- boosting urgency-preferred candidates
+- filtering candidates outside `maxDistanceKm`
+- adding verification checkpoint confidence bonus
+
+### Edge cases and limits
+
+- If all volunteers are filtered out by preferences/distance, routing falls back to existing deterministic hierarchy.
+- If optional preference fields are missing, baseline Phase 5 routing behavior remains valid.
+- Tie breaks remain deterministic (`priority desc`, then destination id asc).
+
+## Test coverage
+
+- Directory metadata normalization and query filtering
+- Directory create/update/delete lifecycle propagation
+- Volunteer onboarding validation + create/edit profile persistence
+- Preference-aware routing candidate generation
+- API-level volunteer upsert/list + preference-aware route tests
+- Web UX tests for overlays, details, and accessible UI states

--- a/docs/at-protocol/lexicon-versioning.md
+++ b/docs/at-protocol/lexicon-versioning.md
@@ -4,13 +4,21 @@ This document defines the v1 AT Lexicon schema set, constraints, and evolution p
 
 ## v1 schema set
 
-All records are published with revision `1.0.0`:
+Records are currently published at:
 
 - `app.mutualhub.aid.post`
 - `app.mutualhub.volunteer.profile`
 - `app.mutualhub.conversation.meta`
 - `app.mutualhub.moderation.report`
 - `app.mutualhub.directory.resource`
+
+Revision map:
+
+- `app.mutualhub.aid.post`: `1.0.0`
+- `app.mutualhub.volunteer.profile`: `1.1.0`
+- `app.mutualhub.conversation.meta`: `1.0.0`
+- `app.mutualhub.moderation.report`: `1.0.0`
+- `app.mutualhub.directory.resource`: `1.1.0`
 
 Canonical schema JSON files live in:
 
@@ -47,6 +55,10 @@ Key constraints:
 - `displayName`: 1..80 chars
 - `capabilities`: non-empty array
 - `availability`: `immediate | within-24h | scheduled | unavailable`
+- `skills` (optional): non-empty array, each item 1..64 chars
+- `availabilityWindows` (optional): non-empty array, each item 1..64 chars
+- `verificationCheckpoints` (optional): identity/safety/reference status object
+- `matchingPreferences` (optional): preferred categories + urgencies + max distance
 
 ### `app.mutualhub.conversation.meta`
 
@@ -84,6 +96,10 @@ Key constraints:
 - `serviceArea`: 1..120 chars
 - `contact`: must include at least one of `url` or `phone`
 - `verificationStatus`: `unverified | community-verified | partner-verified`
+- `location` (optional): bounded lat/lng + precisionKm + optional areaLabel
+- `openHours` (optional): 1..200 chars
+- `eligibilityNotes` (optional): 1..500 chars
+- `operationalStatus` (optional): `open | limited | closed`
 
 ## Semantic versioning policy
 

--- a/packages/at-lexicons/src/fixtures/valid/directory-resource.json
+++ b/packages/at-lexicons/src/fixtures/valid/directory-resource.json
@@ -1,6 +1,6 @@
 {
     "$type": "app.mutualhub.directory.resource",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "name": "Downtown Community Pantry",
     "category": "food-bank",
     "serviceArea": "Downtown + adjacent neighborhoods",
@@ -8,5 +8,14 @@
         "url": "https://example.org/pantry"
     },
     "verificationStatus": "community-verified",
+    "location": {
+        "latitude": 40.7129,
+        "longitude": -74.0033,
+        "precisionKm": 1.5,
+        "areaLabel": "Downtown Core"
+    },
+    "openHours": "Mon-Fri 09:00-18:00; Sat 09:00-13:00",
+    "eligibilityNotes": "Open to all residents with no ID requirement",
+    "operationalStatus": "open",
     "createdAt": "2026-02-26T11:25:00.000Z"
 }

--- a/packages/at-lexicons/src/fixtures/valid/volunteer-profile.json
+++ b/packages/at-lexicons/src/fixtures/valid/volunteer-profile.json
@@ -1,9 +1,22 @@
 {
     "$type": "app.mutualhub.volunteer.profile",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "displayName": "Alex Rivera",
     "capabilities": ["transport", "food-delivery"],
     "availability": "within-24h",
     "contactPreference": "chat-or-call",
+    "skills": ["route planning", "meal delivery"],
+    "availabilityWindows": ["weekday_evenings", "weekend_mornings"],
+    "verificationCheckpoints": {
+        "identityCheck": "approved",
+        "safetyTraining": "approved",
+        "communityReference": "pending"
+    },
+    "matchingPreferences": {
+        "preferredCategories": ["food", "transport"],
+        "preferredUrgencies": ["medium", "high", "critical"],
+        "maxDistanceKm": 18,
+        "acceptsLateNight": true
+    },
     "createdAt": "2026-02-26T10:30:00.000Z"
 }

--- a/packages/at-lexicons/src/lexicons.test.ts
+++ b/packages/at-lexicons/src/lexicons.test.ts
@@ -66,7 +66,7 @@ describe('P2.1 lexicon schemas', () => {
         expect(Object.keys(lexiconDocs).sort()).toEqual(
             Object.values(recordNsid).sort(),
         );
-        expect(LEXICON_SET_VERSION).toBe('1.0.0');
+        expect(LEXICON_SET_VERSION).toBe('1.1.0');
 
         for (const nsid of Object.values(recordNsid)) {
             const lexicon = lexiconDocs[nsid];

--- a/packages/at-lexicons/src/lexicons/app.mutualhub.directory.resource.v1.json
+++ b/packages/at-lexicons/src/lexicons/app.mutualhub.directory.resource.v1.json
@@ -1,7 +1,7 @@
 {
     "lexicon": 1,
     "id": "app.mutualhub.directory.resource",
-    "revision": "1.0.0",
+    "revision": "1.1.0",
     "description": "Resource directory listing record.",
     "defs": {
         "main": {
@@ -24,12 +24,22 @@
                         "type": "string",
                         "const": "app.mutualhub.directory.resource"
                     },
-                    "version": { "type": "string", "const": "1.0.0" },
+                    "version": {
+                        "type": "string",
+                        "enum": ["1.0.0", "1.1.0"]
+                    },
                     "name": { "type": "string", "maxLength": 120 },
                     "category": { "type": "string" },
                     "serviceArea": { "type": "string", "maxLength": 120 },
                     "contact": { "type": "object" },
                     "verificationStatus": { "type": "string" },
+                    "location": { "type": "object" },
+                    "openHours": { "type": "string", "maxLength": 200 },
+                    "eligibilityNotes": {
+                        "type": "string",
+                        "maxLength": 500
+                    },
+                    "operationalStatus": { "type": "string" },
                     "createdAt": { "type": "string", "format": "datetime" },
                     "updatedAt": { "type": "string", "format": "datetime" }
                 }

--- a/packages/at-lexicons/src/lexicons/app.mutualhub.volunteer.profile.v1.json
+++ b/packages/at-lexicons/src/lexicons/app.mutualhub.volunteer.profile.v1.json
@@ -1,7 +1,7 @@
 {
     "lexicon": 1,
     "id": "app.mutualhub.volunteer.profile",
-    "revision": "1.0.0",
+    "revision": "1.1.0",
     "description": "Volunteer profile and availability metadata.",
     "defs": {
         "main": {
@@ -23,11 +23,18 @@
                         "type": "string",
                         "const": "app.mutualhub.volunteer.profile"
                     },
-                    "version": { "type": "string", "const": "1.0.0" },
+                    "version": {
+                        "type": "string",
+                        "enum": ["1.0.0", "1.1.0"]
+                    },
                     "displayName": { "type": "string", "maxLength": 80 },
                     "capabilities": { "type": "array" },
                     "availability": { "type": "string" },
                     "contactPreference": { "type": "string" },
+                    "skills": { "type": "array" },
+                    "availabilityWindows": { "type": "array" },
+                    "verificationCheckpoints": { "type": "object" },
+                    "matchingPreferences": { "type": "object" },
                     "notes": { "type": "string", "maxLength": 500 },
                     "createdAt": { "type": "string", "format": "datetime" },
                     "updatedAt": { "type": "string", "format": "datetime" }

--- a/packages/at-lexicons/src/validators.ts
+++ b/packages/at-lexicons/src/validators.ts
@@ -18,20 +18,24 @@ const atUriSchema = z
     .regex(/^at:\/\/[^\s]+$/i, 'Expected a valid at:// URI');
 const isoDateTimeSchema = z.string().datetime({ offset: true });
 
+const aidCategoryValues = [
+    'food',
+    'shelter',
+    'medical',
+    'transport',
+    'childcare',
+    'other',
+] as const;
+
+const aidUrgencyValues = ['low', 'medium', 'high', 'critical'] as const;
+
 export const aidPostSchema = z.object({
     $type: z.literal(recordNsid.aidPost),
     version: z.literal('1.0.0'),
     title: z.string().min(1).max(140),
     description: z.string().min(1).max(5000),
-    category: z.enum([
-        'food',
-        'shelter',
-        'medical',
-        'transport',
-        'childcare',
-        'other',
-    ]),
-    urgency: z.enum(['low', 'medium', 'high', 'critical']),
+    category: z.enum(aidCategoryValues),
+    urgency: z.enum(aidUrgencyValues),
     status: z.enum(['open', 'in-progress', 'resolved', 'closed']),
     location: z.object({
         latitude: z.number().min(-90).max(90),
@@ -44,7 +48,7 @@ export const aidPostSchema = z.object({
 
 export const volunteerProfileSchema = z.object({
     $type: z.literal(recordNsid.volunteerProfile),
-    version: z.literal('1.0.0'),
+    version: z.enum(['1.0.0', '1.1.0']),
     displayName: z.string().min(1).max(80),
     capabilities: z
         .array(
@@ -65,6 +69,27 @@ export const volunteerProfileSchema = z.object({
         'unavailable',
     ]),
     contactPreference: z.enum(['chat-only', 'chat-or-call']),
+    skills: z.array(z.string().min(1).max(64)).min(1).max(50).optional(),
+    availabilityWindows: z
+        .array(z.string().min(1).max(64))
+        .min(1)
+        .max(50)
+        .optional(),
+    verificationCheckpoints: z
+        .object({
+            identityCheck: z.enum(['pending', 'approved', 'rejected']),
+            safetyTraining: z.enum(['pending', 'approved', 'rejected']),
+            communityReference: z.enum(['pending', 'approved', 'rejected']),
+        })
+        .optional(),
+    matchingPreferences: z
+        .object({
+            preferredCategories: z.array(z.enum(aidCategoryValues)).min(1),
+            preferredUrgencies: z.array(z.enum(aidUrgencyValues)).min(1),
+            maxDistanceKm: z.number().min(1).max(250),
+            acceptsLateNight: z.boolean().optional(),
+        })
+        .optional(),
     notes: z.string().max(500).optional(),
     createdAt: isoDateTimeSchema,
     updatedAt: isoDateTimeSchema.optional(),
@@ -92,7 +117,7 @@ export const moderationReportSchema = z.object({
 
 export const directoryResourceSchema = z.object({
     $type: z.literal(recordNsid.directoryResource),
-    version: z.literal('1.0.0'),
+    version: z.enum(['1.0.0', '1.1.0']),
     name: z.string().min(1).max(120),
     category: z.enum([
         'food-bank',
@@ -116,6 +141,17 @@ export const directoryResourceSchema = z.object({
         'community-verified',
         'partner-verified',
     ]),
+    location: z
+        .object({
+            latitude: z.number().min(-90).max(90),
+            longitude: z.number().min(-180).max(180),
+            precisionKm: z.number().min(0.1).max(50),
+            areaLabel: z.string().min(1).max(120).optional(),
+        })
+        .optional(),
+    openHours: z.string().min(1).max(200).optional(),
+    eligibilityNotes: z.string().min(1).max(500).optional(),
+    operationalStatus: z.enum(['open', 'limited', 'closed']).optional(),
     createdAt: isoDateTimeSchema,
     updatedAt: isoDateTimeSchema.optional(),
 });

--- a/packages/at-lexicons/src/versioning.ts
+++ b/packages/at-lexicons/src/versioning.ts
@@ -1,4 +1,4 @@
-export const LEXICON_SET_VERSION = '1.0.0';
+export const LEXICON_SET_VERSION = '1.1.0';
 
 export const LEXICON_VERSION_POLICY = {
     baseline: 'All v1 record schemas are published as 1.0.0 lexicon revisions.',
@@ -11,10 +11,10 @@ export const LEXICON_VERSION_POLICY = {
 
 export const LEXICON_SCHEMA_REVISIONS = {
     'app.mutualhub.aid.post': '1.0.0',
-    'app.mutualhub.volunteer.profile': '1.0.0',
+    'app.mutualhub.volunteer.profile': '1.1.0',
     'app.mutualhub.conversation.meta': '1.0.0',
     'app.mutualhub.moderation.report': '1.0.0',
-    'app.mutualhub.directory.resource': '1.0.0',
+    'app.mutualhub.directory.resource': '1.1.0',
 } as const;
 
 export const isSemver = (value: string): boolean =>

--- a/packages/shared/src/contracts.ts
+++ b/packages/shared/src/contracts.ts
@@ -1,4 +1,4 @@
-export const CONTRACT_VERSION = '0.5.0-phase5';
+export const CONTRACT_VERSION = '0.6.0-phase6';
 
 export type DomainName =
     | 'identity'
@@ -75,6 +75,10 @@ export interface ApiQueryAidResponse {
 export interface ApiQueryDirectoryRequest {
     category?: string;
     status?: 'unverified' | 'community-verified' | 'partner-verified';
+    operationalStatus?: 'open' | 'limited' | 'closed';
+    latitude?: number;
+    longitude?: number;
+    radiusKm?: number;
     freshnessHours?: number;
     searchText?: string;
     page?: number;
@@ -88,6 +92,47 @@ export interface DirectoryRecordSummary {
     category: string;
     serviceArea: string;
     status: 'unverified' | 'community-verified' | 'partner-verified';
+    contact: {
+        url?: string;
+        phone?: string;
+    };
+    approximateGeo?: {
+        latitude: number;
+        longitude: number;
+        precisionKm: number;
+    };
+    openHours?: string;
+    eligibilityNotes?: string;
+    operationalStatus: 'open' | 'limited' | 'closed';
+    createdAt: string;
+    updatedAt: string;
+}
+
+export interface VolunteerVerificationCheckpointState {
+    identityCheck: 'pending' | 'approved' | 'rejected';
+    safetyTraining: 'pending' | 'approved' | 'rejected';
+    communityReference: 'pending' | 'approved' | 'rejected';
+}
+
+export interface VolunteerMatchingPreferences {
+    preferredCategories: Array<
+        'food' | 'shelter' | 'medical' | 'transport' | 'childcare' | 'other'
+    >;
+    preferredUrgencies: Array<'low' | 'medium' | 'high' | 'critical'>;
+    maxDistanceKm: number;
+    acceptsLateNight?: boolean;
+}
+
+export interface VolunteerProfileSummary {
+    did: string;
+    displayName: string;
+    capabilities: string[];
+    availability: 'immediate' | 'within-24h' | 'scheduled' | 'unavailable';
+    contactPreference: 'chat-only' | 'chat-or-call';
+    skills: string[];
+    availabilityWindows: string[];
+    verificationCheckpoints: VolunteerVerificationCheckpointState;
+    matchingPreferences: VolunteerMatchingPreferences;
     createdAt: string;
     updatedAt: string;
 }

--- a/packages/shared/src/discovery.test.ts
+++ b/packages/shared/src/discovery.test.ts
@@ -112,6 +112,110 @@ describe('P3.2/P3.3 discovery indexing + query APIs', () => {
 
         expect(filtered.total).toBe(1);
         expect(filtered.items[0]?.name).toContain('Pantry');
+        expect(filtered.items[0]?.openHours).toContain('Mon-Fri');
+        expect(filtered.items[0]?.eligibilityNotes).toContain('residents');
+    });
+
+    it('applies directory create/update/delete lifecycle events deterministically', () => {
+        const store = buildStore();
+
+        store.applyEvent({
+            eventId: '6:create:directory-c',
+            seq: 6,
+            action: 'create',
+            uri: 'at://did:example:ella/app.mutualhub.directory.resource/resource-c',
+            collection: recordNsid.directoryResource,
+            authorDid: 'did:example:ella',
+            receivedAt: '2026-02-26T12:06:00.000Z',
+            payload: {
+                kind: 'directory-resource',
+                name: 'Late Night Food Hub',
+                serviceArea: 'West district',
+                category: 'food-bank',
+                verificationStatus: 'partner-verified',
+                contact: {
+                    phone: '+1-555-0900',
+                },
+                approximateGeo: {
+                    latitude: 40.715,
+                    longitude: -74.001,
+                    precisionKm: 1.8,
+                },
+                openHours: 'Daily 20:00-02:00',
+                eligibilityNotes: 'Walk-ins welcome for emergency meals',
+                operationalStatus: 'open',
+                createdAt: '2026-02-26T12:06:00.000Z',
+                updatedAt: '2026-02-26T12:06:00.000Z',
+                searchableText:
+                    'late night food hub west district food-bank partner-verified daily 20:00-02:00 walk-ins welcome emergency meals',
+                trustScore: 0.88,
+            },
+        });
+
+        const created = store.queryDirectory({
+            searchText: 'emergency meals',
+            nowIso: '2026-02-26T13:00:00.000Z',
+        });
+        expect(created.total).toBe(1);
+        expect(created.items[0]?.name).toBe('Late Night Food Hub');
+
+        store.applyEvent({
+            eventId: '7:update:directory-c',
+            seq: 7,
+            action: 'update',
+            uri: 'at://did:example:ella/app.mutualhub.directory.resource/resource-c',
+            collection: recordNsid.directoryResource,
+            authorDid: 'did:example:ella',
+            receivedAt: '2026-02-26T12:07:00.000Z',
+            payload: {
+                kind: 'directory-resource',
+                name: 'Late Night Food Hub',
+                serviceArea: 'West district',
+                category: 'food-bank',
+                verificationStatus: 'partner-verified',
+                contact: {
+                    phone: '+1-555-0900',
+                },
+                approximateGeo: {
+                    latitude: 40.715,
+                    longitude: -74.001,
+                    precisionKm: 1.8,
+                },
+                openHours: 'Daily 18:00-03:00',
+                eligibilityNotes: 'Emergency meals and grocery packs',
+                operationalStatus: 'limited',
+                createdAt: '2026-02-26T12:06:00.000Z',
+                updatedAt: '2026-02-26T12:07:00.000Z',
+                searchableText:
+                    'late night food hub west district food-bank partner-verified daily 18:00-03:00 emergency meals grocery packs',
+                trustScore: 0.88,
+            },
+        });
+
+        const updated = store.queryDirectory({
+            operationalStatus: 'limited',
+            searchText: 'grocery packs',
+            nowIso: '2026-02-26T13:00:00.000Z',
+        });
+        expect(updated.total).toBe(1);
+        expect(updated.items[0]?.openHours).toContain('18:00-03:00');
+
+        store.applyEvent({
+            eventId: '8:delete:directory-c',
+            seq: 8,
+            action: 'delete',
+            uri: 'at://did:example:ella/app.mutualhub.directory.resource/resource-c',
+            collection: recordNsid.directoryResource,
+            authorDid: 'did:example:ella',
+            receivedAt: '2026-02-26T12:08:00.000Z',
+            deleteReason: 'closed-offline',
+        });
+
+        const deleted = store.queryDirectory({
+            searchText: 'late night food hub',
+            nowIso: '2026-02-26T13:00:00.000Z',
+        });
+        expect(deleted.total).toBe(0);
     });
 
     it('validates aid and directory query payloads', () => {
@@ -126,6 +230,13 @@ describe('P3.2/P3.3 discovery indexing + query APIs', () => {
         expect(() =>
             validateDirectoryQueryInput({
                 page: 0,
+            }),
+        ).toThrow();
+
+        expect(() =>
+            validateDirectoryQueryInput({
+                latitude: 1.3,
+                radiusKm: 5,
             }),
         ).toThrow();
 

--- a/packages/shared/src/discovery.ts
+++ b/packages/shared/src/discovery.ts
@@ -41,6 +41,10 @@ export interface AidQueryInput extends PaginationInput {
 export interface DirectoryQueryInput extends PaginationInput {
     category?: string;
     status?: 'unverified' | 'community-verified' | 'partner-verified';
+    operationalStatus?: 'open' | 'limited' | 'closed';
+    latitude?: number;
+    longitude?: number;
+    radiusKm?: number;
     freshnessHours?: number;
     searchText?: string;
     nowIso?: string;
@@ -76,6 +80,14 @@ export interface DirectoryCard {
     category: string;
     serviceArea: string;
     status: 'unverified' | 'community-verified' | 'partner-verified';
+    contact: {
+        url?: string;
+        phone?: string;
+    };
+    approximateGeo?: ApproximateGeoPoint;
+    openHours?: string;
+    eligibilityNotes?: string;
+    operationalStatus: 'open' | 'limited' | 'closed';
     createdAt: string;
     updatedAt: string;
 }
@@ -186,6 +198,11 @@ export class DiscoveryIndexStore {
 
     private readonly directoryCategoryIndex = new Map<string, Set<string>>();
     private readonly directoryStatusIndex = new Map<string, Set<string>>();
+    private readonly directoryOperationalStatusIndex = new Map<
+        string,
+        Set<string>
+    >();
+    private readonly directoryGeoIndex = new Map<string, Set<string>>();
     private readonly directoryTextIndex = new Map<string, Set<string>>();
 
     applyEvent(event: NormalizedFirehoseEvent): void {
@@ -232,6 +249,27 @@ export class DiscoveryIndexStore {
         const candidates = this.collectDirectoryCandidates(input);
 
         const filtered = candidates.filter(record => {
+            if (
+                input.latitude !== undefined &&
+                input.longitude !== undefined &&
+                input.radiusKm !== undefined
+            ) {
+                if (!record.approximateGeo) {
+                    return false;
+                }
+
+                const distanceKm = haversineDistanceKm(
+                    input.latitude,
+                    input.longitude,
+                    record.approximateGeo.latitude,
+                    record.approximateGeo.longitude,
+                );
+
+                if (distanceKm > input.radiusKm) {
+                    return false;
+                }
+            }
+
             if (input.freshnessHours !== undefined) {
                 const recordMs = new Date(record.updatedAt).getTime();
                 if (!Number.isFinite(recordMs)) {
@@ -262,6 +300,11 @@ export class DiscoveryIndexStore {
                 category: record.category,
                 serviceArea: record.serviceArea,
                 status: record.verificationStatus,
+                contact: record.contact,
+                approximateGeo: record.approximateGeo,
+                openHours: record.openHours,
+                eligibilityNotes: record.eligibilityNotes,
+                operationalStatus: record.operationalStatus,
                 createdAt: record.createdAt,
                 updatedAt: record.updatedAt,
             }))
@@ -284,6 +327,7 @@ export class DiscoveryIndexStore {
         geoBuckets: number;
         aidTextTerms: number;
         directoryTextTerms: number;
+        directoryGeoBuckets: number;
     } {
         return {
             aidRecords: this.aidRecords.size,
@@ -291,6 +335,7 @@ export class DiscoveryIndexStore {
             geoBuckets: this.aidGeoIndex.size,
             aidTextTerms: this.aidTextIndex.size,
             directoryTextTerms: this.directoryTextIndex.size,
+            directoryGeoBuckets: this.directoryGeoIndex.size,
         };
     }
 
@@ -422,6 +467,16 @@ export class DiscoveryIndexStore {
             );
         }
 
+        if (input.operationalStatus) {
+            sets.push(
+                new Set(
+                    this.directoryOperationalStatusIndex.get(
+                        input.operationalStatus,
+                    ) ?? [],
+                ),
+            );
+        }
+
         const uriSet =
             sets.length === 0 ?
                 new Set(this.directoryRecords.keys())
@@ -509,6 +564,19 @@ export class DiscoveryIndexStore {
 
         addToIndex(this.directoryCategoryIndex, indexed.category, uri);
         addToIndex(this.directoryStatusIndex, indexed.verificationStatus, uri);
+        addToIndex(
+            this.directoryOperationalStatusIndex,
+            indexed.operationalStatus,
+            uri,
+        );
+
+        if (indexed.approximateGeo) {
+            addToIndex(
+                this.directoryGeoIndex,
+                geoBucket(indexed.approximateGeo),
+                uri,
+            );
+        }
 
         for (const token of toTokenSet(indexed.searchableText)) {
             addToIndex(this.directoryTextIndex, token, uri);
@@ -528,6 +596,19 @@ export class DiscoveryIndexStore {
             existing.verificationStatus,
             uri,
         );
+        removeFromIndex(
+            this.directoryOperationalStatusIndex,
+            existing.operationalStatus,
+            uri,
+        );
+
+        if (existing.approximateGeo) {
+            removeFromIndex(
+                this.directoryGeoIndex,
+                geoBucket(existing.approximateGeo),
+                uri,
+            );
+        }
 
         for (const token of toTokenSet(existing.searchableText)) {
             removeFromIndex(this.directoryTextIndex, token, uri);
@@ -556,22 +637,47 @@ const aidQuerySchema = z.object({
     nowIso: z.string().datetime({ offset: true }).optional(),
 });
 
-const directoryQuerySchema = z.object({
-    category: z.string().min(1).max(64).optional(),
-    status: z
-        .enum(['unverified', 'community-verified', 'partner-verified'])
-        .optional(),
-    freshnessHours: z
-        .number()
-        .int()
-        .positive()
-        .max(24 * 365)
-        .optional(),
-    searchText: z.string().min(1).max(120).optional(),
-    page: z.number().int().positive().optional(),
-    pageSize: z.number().int().positive().max(MAX_PAGE_SIZE).optional(),
-    nowIso: z.string().datetime({ offset: true }).optional(),
-});
+const directoryQuerySchema = z
+    .object({
+        category: z.string().min(1).max(64).optional(),
+        status: z
+            .enum(['unverified', 'community-verified', 'partner-verified'])
+            .optional(),
+        operationalStatus: z.enum(['open', 'limited', 'closed']).optional(),
+        latitude: z.number().min(-90).max(90).optional(),
+        longitude: z.number().min(-180).max(180).optional(),
+        radiusKm: z.number().positive().max(250).optional(),
+        freshnessHours: z
+            .number()
+            .int()
+            .positive()
+            .max(24 * 365)
+            .optional(),
+        searchText: z.string().min(1).max(120).optional(),
+        page: z.number().int().positive().optional(),
+        pageSize: z.number().int().positive().max(MAX_PAGE_SIZE).optional(),
+        nowIso: z.string().datetime({ offset: true }).optional(),
+    })
+    .superRefine((value, ctx) => {
+        const geoProvided =
+            value.latitude !== undefined ||
+            value.longitude !== undefined ||
+            value.radiusKm !== undefined;
+
+        if (
+            geoProvided &&
+            (value.latitude === undefined ||
+                value.longitude === undefined ||
+                value.radiusKm === undefined)
+        ) {
+            ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                message:
+                    'latitude, longitude, and radiusKm must be supplied together.',
+                path: ['latitude'],
+            });
+        }
+    });
 
 export const validateAidQueryInput = (input: unknown): AidQueryInput =>
     aidQuerySchema.parse(input);

--- a/packages/shared/src/firehose.test.ts
+++ b/packages/shared/src/firehose.test.ts
@@ -114,4 +114,45 @@ describe('P3.1 firehose consumer + normalization', () => {
             expect(normalized.event.authorDid).toBe('did:example:alice');
         }
     });
+
+    it('normalizes directory operational metadata for indexing/search', () => {
+        const normalized = normalizeFirehoseEvent({
+            seq: 51,
+            action: 'create',
+            uri: 'at://did:example:org/app.mutualhub.directory.resource/resource-z',
+            collection: recordNsid.directoryResource,
+            authorDid: 'did:example:org',
+            record: {
+                $type: recordNsid.directoryResource,
+                version: '1.1.0',
+                name: 'Rapid Clinic',
+                category: 'clinic',
+                serviceArea: 'North zone',
+                contact: {
+                    phone: '+1-555-0101',
+                },
+                verificationStatus: 'partner-verified',
+                location: {
+                    latitude: 40.719,
+                    longitude: -74.001,
+                    precisionKm: 1.2,
+                    areaLabel: 'North Zone',
+                },
+                openHours: '24/7',
+                eligibilityNotes: 'Urgent cases prioritized',
+                operationalStatus: 'open',
+                createdAt: '2026-02-26T12:00:00.000Z',
+            },
+        });
+
+        expect(normalized.success).toBe(true);
+        if (normalized.success) {
+            expect(normalized.event.payload).toMatchObject({
+                kind: 'directory-resource',
+                openHours: '24/7',
+                eligibilityNotes: 'Urgent cases prioritized',
+                operationalStatus: 'open',
+            });
+        }
+    });
 });

--- a/packages/shared/src/firehose.ts
+++ b/packages/shared/src/firehose.ts
@@ -67,6 +67,11 @@ export interface NormalizedDirectoryResource {
     serviceArea: string;
     category: DirectoryResourceRecord['category'];
     verificationStatus: DirectoryResourceRecord['verificationStatus'];
+    contact: DirectoryResourceRecord['contact'];
+    approximateGeo?: ApproximateGeoPoint;
+    openHours?: string;
+    eligibilityNotes?: string;
+    operationalStatus: 'open' | 'limited' | 'closed';
     createdAt: string;
     updatedAt: string;
     searchableText: string;
@@ -258,6 +263,18 @@ const normalizeRecordPayload = (
             serviceArea: directoryRecord.serviceArea,
             category: directoryRecord.category,
             verificationStatus: directoryRecord.verificationStatus,
+            contact: directoryRecord.contact,
+            approximateGeo:
+                directoryRecord.location ?
+                    quantizeCoordinate(
+                        directoryRecord.location.latitude,
+                        directoryRecord.location.longitude,
+                        directoryRecord.location.precisionKm,
+                    )
+                :   undefined,
+            openHours: directoryRecord.openHours,
+            eligibilityNotes: directoryRecord.eligibilityNotes,
+            operationalStatus: directoryRecord.operationalStatus ?? 'open',
             createdAt: directoryRecord.createdAt,
             updatedAt: directoryRecord.updatedAt ?? directoryRecord.createdAt,
             searchableText: normalizeSearchableText(
@@ -265,6 +282,10 @@ const normalizeRecordPayload = (
                 directoryRecord.serviceArea,
                 directoryRecord.category,
                 directoryRecord.verificationStatus,
+                directoryRecord.openHours ?? '',
+                directoryRecord.eligibilityNotes ?? '',
+                directoryRecord.location?.areaLabel ?? '',
+                directoryRecord.operationalStatus ?? 'open',
             ),
             trustScore,
         };
@@ -517,7 +538,7 @@ export const buildPhase3FixtureFirehoseEvents = (): unknown[] => {
             trustScore: 0.95,
             record: {
                 $type: recordNsid.directoryResource,
-                version: '1.0.0',
+                version: '1.1.0',
                 name: 'Downtown Community Pantry',
                 category: 'food-bank',
                 serviceArea: 'Downtown and east side',
@@ -525,6 +546,15 @@ export const buildPhase3FixtureFirehoseEvents = (): unknown[] => {
                     url: 'https://example.org/pantry',
                 },
                 verificationStatus: 'community-verified',
+                location: {
+                    latitude: 40.712,
+                    longitude: -74.003,
+                    precisionKm: 1.5,
+                    areaLabel: 'Downtown',
+                },
+                openHours: 'Mon-Fri 09:00-18:00',
+                eligibilityNotes: 'Open to all residents',
+                operationalStatus: 'open',
                 createdAt: '2026-02-26T09:00:00.000Z',
             },
         },
@@ -563,7 +593,7 @@ export const buildPhase3FixtureFirehoseEvents = (): unknown[] => {
             trustScore: 0.75,
             record: {
                 $type: recordNsid.directoryResource,
-                version: '1.0.0',
+                version: '1.1.0',
                 name: 'Night Shelter East',
                 category: 'shelter',
                 serviceArea: 'East district',
@@ -571,6 +601,15 @@ export const buildPhase3FixtureFirehoseEvents = (): unknown[] => {
                     phone: '+1-555-0200',
                 },
                 verificationStatus: 'partner-verified',
+                location: {
+                    latitude: 40.728,
+                    longitude: -73.998,
+                    precisionKm: 2,
+                    areaLabel: 'East District',
+                },
+                openHours: 'Daily 18:00-08:00',
+                eligibilityNotes: 'Adults 18+ with same-day intake',
+                operationalStatus: 'open',
                 createdAt: '2026-02-25T23:00:00.000Z',
             },
         },

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -7,3 +7,4 @@ export * from './messaging.js';
 export * from './ranking.js';
 export * from '@mutual-hub/at-lexicons';
 export * from './records.js';
+export * from './volunteer-onboarding.js';

--- a/packages/shared/src/messaging.test.ts
+++ b/packages/shared/src/messaging.test.ts
@@ -56,7 +56,9 @@ describe('P5.2 deterministic routing assistant', () => {
         for (const fixture of fixtures) {
             const result = assistant.decide(fixture.input);
             expect(result.matchedRule).toBe(fixture.expectedRule);
-            expect(result.destinationKind).toBe(fixture.expectedDestinationKind);
+            expect(result.destinationKind).toBe(
+                fixture.expectedDestinationKind,
+            );
             expect(result.machineRationale.length).toBeGreaterThan(0);
             expect(result.humanRationale.length).toBeGreaterThan(0);
         }
@@ -92,6 +94,53 @@ describe('P5.2 deterministic routing assistant', () => {
 
         expect(result.destinationKind).toBe('volunteer-pool');
         expect(result.destinationId).toBe('volunteer:v-a');
+    });
+
+    it('applies volunteer preference signals and distance caps deterministically', () => {
+        const assistant = new DeterministicRoutingAssistant();
+
+        const result = assistant.decide({
+            aidPostUri: 'at://did:example:alice/app.mutualhub.aid.post/post-3b',
+            requesterDid: 'did:example:requester',
+            aidCategory: 'medical',
+            urgency: 'critical',
+            volunteerCandidates: [
+                {
+                    id: 'v-a',
+                    did: 'did:example:v-a',
+                    availability: 'immediate',
+                    trustScore: 0.8,
+                    matchesCategory: true,
+                    preferredCategories: ['medical'],
+                    preferredUrgencyLevels: ['critical'],
+                    maxDistanceKm: 8,
+                    distanceKm: 7,
+                    verificationCheckpointScore: 1,
+                },
+                {
+                    id: 'v-b',
+                    did: 'did:example:v-b',
+                    availability: 'immediate',
+                    trustScore: 0.9,
+                    matchesCategory: true,
+                    preferredCategories: ['food'],
+                    preferredUrgencyLevels: ['low'],
+                    maxDistanceKm: 5,
+                    distanceKm: 7,
+                    verificationCheckpointScore: 0.33,
+                },
+            ],
+            resourceCandidates: [],
+            now: '2026-02-26T15:12:00.000Z',
+        });
+
+        expect(result.destinationKind).toBe('volunteer-pool');
+        expect(result.destinationId).toBe('volunteer:v-a');
+        expect(
+            result.machineRationale.some(reason =>
+                reason.includes('preferred-category=true'),
+            ),
+        ).toBe(true);
     });
 });
 
@@ -226,7 +275,11 @@ describe('P5.4 safety controls + abuse protections', () => {
         });
 
         expect(report.reportRecord.reason).toBe('abuse');
-        expect(report.moderationSignal.type).toBe('moderation.review.requested');
-        expect(safety.drainModerationSignals().length).toBeGreaterThanOrEqual(2);
+        expect(report.moderationSignal.type).toBe(
+            'moderation.review.requested',
+        );
+        expect(safety.drainModerationSignals().length).toBeGreaterThanOrEqual(
+            2,
+        );
     });
 });

--- a/packages/shared/src/messaging.ts
+++ b/packages/shared/src/messaging.ts
@@ -117,8 +117,8 @@ export const createPostLinkedChatContext = (
 
     validateInitiationPermission(input);
 
-    const participantDids = [initiatedByDid, recipientDid].sort(
-        (left, right) => left.localeCompare(right),
+    const participantDids = [initiatedByDid, recipientDid].sort((left, right) =>
+        left.localeCompare(right),
     );
     const conversationKey = buildConversationKey(aidPostUri, participantDids);
     const conversationUri = `at://${participantDids[0]}/${recordNsid.conversationMeta}/conv-${conversationKey}`;
@@ -156,11 +156,19 @@ export interface VolunteerRoutingCandidate {
     availability: 'immediate' | 'within-24h' | 'scheduled' | 'unavailable';
     trustScore: number;
     matchesCategory: boolean;
+    preferredCategories?: readonly AidPostRecord['category'][];
+    preferredUrgencyLevels?: readonly AidPostRecord['urgency'][];
+    maxDistanceKm?: number;
+    distanceKm?: number;
+    verificationCheckpointScore?: number;
 }
 
 export interface ResourceRoutingCandidate {
     id: string;
-    verificationStatus: 'unverified' | 'community-verified' | 'partner-verified';
+    verificationStatus:
+        | 'unverified'
+        | 'community-verified'
+        | 'partner-verified';
     supportsCategory: boolean;
     currentlyOpen: boolean;
 }
@@ -302,9 +310,31 @@ export class DeterministicRoutingAssistant {
                 continue;
             }
 
+            if (
+                volunteer.maxDistanceKm !== undefined &&
+                volunteer.distanceKm !== undefined &&
+                volunteer.distanceKm > volunteer.maxDistanceKm
+            ) {
+                continue;
+            }
+
             const trustScore = Math.max(0, Math.min(1, volunteer.trustScore));
             const trustBonus = Math.round(trustScore * 20);
             const categoryBonus = volunteer.matchesCategory ? 12 : 0;
+            const preferredCategoryBonus =
+                volunteer.preferredCategories?.includes(input.aidCategory) ?
+                    10
+                :   0;
+            const preferredUrgencyBonus =
+                volunteer.preferredUrgencyLevels?.includes(input.urgency) ?
+                    8
+                :   0;
+            const verificationBonus = Math.round(
+                Math.max(
+                    0,
+                    Math.min(1, volunteer.verificationCheckpointScore ?? 0),
+                ) * 10,
+            );
             const urgencyBonus =
                 input.urgency === 'critical' || input.urgency === 'high' ?
                     8
@@ -318,11 +348,17 @@ export class DeterministicRoutingAssistant {
                     availabilityBonus +
                     trustBonus +
                     categoryBonus +
+                    preferredCategoryBonus +
+                    preferredUrgencyBonus +
+                    verificationBonus +
                     urgencyBonus,
                 reasons: [
                     `availability=${volunteer.availability}`,
                     `trust=${trustScore.toFixed(2)}`,
                     `category-match=${volunteer.matchesCategory}`,
+                    `preferred-category=${volunteer.preferredCategories?.includes(input.aidCategory) ?? false}`,
+                    `preferred-urgency=${volunteer.preferredUrgencyLevels?.includes(input.urgency) ?? false}`,
+                    `distanceKm=${volunteer.distanceKm ?? 'n/a'}`,
                     `did=${volunteerDid}`,
                 ],
             });
@@ -337,8 +373,10 @@ export class DeterministicRoutingAssistant {
                 resource.verificationStatus,
             );
             const urgencyBonus =
-                input.urgency === 'critical' &&
-                resource.verificationStatus !== 'unverified' ?
+                (
+                    input.urgency === 'critical' &&
+                    resource.verificationStatus !== 'unverified'
+                ) ?
                     8
                 :   0;
 
@@ -371,11 +409,11 @@ export class DeterministicRoutingAssistant {
             destinationKind: top.destinationKind,
             destinationId: top.destinationId,
             destinationDid:
-                top.destinationKind === 'post-author' ? top.destinationId
-                : undefined,
-            matchedRule:
                 top.destinationKind === 'post-author' ?
-                    'RULE_POST_AUTHOR'
+                    top.destinationId
+                :   undefined,
+            matchedRule:
+                top.destinationKind === 'post-author' ? 'RULE_POST_AUTHOR'
                 : top.destinationKind === 'volunteer-pool' ?
                     'RULE_VOLUNTEER_POOL'
                 : top.destinationKind === 'verified-resource' ?
@@ -464,7 +502,10 @@ export interface PersistedConversationMetadata {
 }
 
 export class ConversationMetadataStore {
-    private readonly conversations = new Map<string, PersistedConversationMetadata>();
+    private readonly conversations = new Map<
+        string,
+        PersistedConversationMetadata
+    >();
 
     upsertConversation(
         input: PersistConversationMetadataInput,
@@ -480,7 +521,8 @@ export class ConversationMetadataStore {
         const recordCandidate = {
             ...input.chat.record,
             status,
-            createdAt: existing?.record.createdAt ?? input.chat.record.createdAt,
+            createdAt:
+                existing?.record.createdAt ?? input.chat.record.createdAt,
             updatedAt: now,
         } satisfies ConversationMetaRecord;
 
@@ -489,14 +531,21 @@ export class ConversationMetadataStore {
             recordCandidate,
         );
 
-        const recipientDid = didSchema.parse(input.recipientCapability.recipientDid);
+        const recipientDid = didSchema.parse(
+            input.recipientCapability.recipientDid,
+        );
         const capability: RecipientTransportCapability = {
             ...input.recipientCapability,
             recipientDid,
-            detectedAt: isoDateTimeSchema.parse(input.recipientCapability.detectedAt),
+            detectedAt: isoDateTimeSchema.parse(
+                input.recipientCapability.detectedAt,
+            ),
         };
 
-        const transportPath = resolveTransportPath(input.routingDecision, capability);
+        const transportPath = resolveTransportPath(
+            input.routingDecision,
+            capability,
+        );
         const fallbackNotice = buildFallbackNotice(transportPath);
 
         const persisted: PersistedConversationMetadata = {
@@ -530,7 +579,10 @@ export class ConversationMetadataStore {
         const normalizedAidPostUri = atUriSchema.parse(aidPostUri);
 
         return [...this.conversations.values()]
-            .filter(conversation => conversation.aidPostUri === normalizedAidPostUri)
+            .filter(
+                conversation =>
+                    conversation.aidPostUri === normalizedAidPostUri,
+            )
             .sort((left, right) =>
                 left.conversationUri.localeCompare(right.conversationUri),
             )
@@ -602,7 +654,9 @@ export class ChatSafetyControls {
     private readonly sendWindows = new Map<string, number[]>();
     private readonly moderationSignals: ModerationReviewRequestedEvent[] = [];
 
-    constructor(private readonly config: ChatSafetyConfig = defaultSafetyConfig) {}
+    constructor(
+        private readonly config: ChatSafetyConfig = defaultSafetyConfig,
+    ) {}
 
     blockParticipant(actorDid: string, targetDid: string): void {
         const actor = didSchema.parse(actorDid);
@@ -735,7 +789,9 @@ export class ChatSafetyControls {
     }
 
     drainModerationSignals(): ModerationReviewRequestedEvent[] {
-        const signals = [...this.moderationSignals].map(signal => clone(signal));
+        const signals = [...this.moderationSignals].map(signal =>
+            clone(signal),
+        );
         this.moderationSignals.length = 0;
         return signals;
     }
@@ -831,6 +887,46 @@ export const buildPhase5RoutingFixtures = (): readonly RoutingFixture[] => {
             },
             expectedRule: 'RULE_VERIFIED_RESOURCE',
             expectedDestinationKind: 'verified-resource',
+        },
+        {
+            id: 'volunteer-preference-aware',
+            input: {
+                aidPostUri:
+                    'at://did:example:requester/app.mutualhub.aid.post/volunteer-2',
+                requesterDid: 'did:example:requester',
+                aidCategory: 'medical',
+                urgency: 'critical',
+                volunteerCandidates: [
+                    {
+                        id: 'v4',
+                        did: 'did:example:volunteer-d',
+                        availability: 'immediate',
+                        trustScore: 0.8,
+                        matchesCategory: true,
+                        preferredCategories: ['medical'],
+                        preferredUrgencyLevels: ['critical', 'high'],
+                        maxDistanceKm: 10,
+                        distanceKm: 4,
+                        verificationCheckpointScore: 1,
+                    },
+                    {
+                        id: 'v5',
+                        did: 'did:example:volunteer-e',
+                        availability: 'immediate',
+                        trustScore: 0.8,
+                        matchesCategory: true,
+                        preferredCategories: ['food'],
+                        preferredUrgencyLevels: ['low'],
+                        maxDistanceKm: 20,
+                        distanceKm: 5,
+                        verificationCheckpointScore: 0.33,
+                    },
+                ],
+                resourceCandidates: [],
+                now: '2026-02-26T14:12:00.000Z',
+            },
+            expectedRule: 'RULE_VOLUNTEER_POOL',
+            expectedDestinationKind: 'volunteer-pool',
         },
     ] as const;
 };

--- a/packages/shared/src/volunteer-onboarding.test.ts
+++ b/packages/shared/src/volunteer-onboarding.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+import {
+    VolunteerOnboardingStore,
+    buildVolunteerRoutingCandidates,
+    summarizeVolunteerCheckpoints,
+    type VolunteerOnboardingDraft,
+} from './volunteer-onboarding.js';
+
+const baseDraft: VolunteerOnboardingDraft = {
+    did: 'did:example:volunteer-a',
+    displayName: 'Ari',
+    capabilities: ['transport', 'food-delivery'],
+    availability: 'within-24h',
+    contactPreference: 'chat-or-call',
+    skills: ['route planning', 'meal delivery'],
+    availabilityWindows: ['weekday_evenings', 'weekend_mornings'],
+    verificationCheckpoints: {
+        identityCheck: 'approved',
+        safetyTraining: 'approved',
+        communityReference: 'pending',
+    },
+    matchingPreferences: {
+        preferredCategories: ['food', 'transport'],
+        preferredUrgencies: ['medium', 'high', 'critical'],
+        maxDistanceKm: 15,
+        acceptsLateNight: true,
+    },
+};
+
+describe('phase 6 volunteer onboarding + profile management', () => {
+    it('creates and updates volunteer profiles with normalized data', () => {
+        const store = new VolunteerOnboardingStore();
+
+        const created = store.upsertProfile(baseDraft, {
+            now: '2026-02-26T18:00:00.000Z',
+        });
+
+        expect(created.record.createdAt).toBe('2026-02-26T18:00:00.000Z');
+        expect(created.record.skills).toEqual([
+            'route planning',
+            'meal delivery',
+        ]);
+
+        const updated = store.upsertProfile(
+            {
+                ...baseDraft,
+                displayName: 'Ari N.',
+                skills: ['route planning', 'route planning', 'meal delivery'],
+                verificationCheckpoints: {
+                    identityCheck: 'approved',
+                    safetyTraining: 'approved',
+                    communityReference: 'approved',
+                },
+            },
+            { now: '2026-02-26T18:10:00.000Z' },
+        );
+
+        expect(updated.record.displayName).toBe('Ari N.');
+        expect(updated.record.createdAt).toBe('2026-02-26T18:00:00.000Z');
+        expect(updated.record.updatedAt).toBe('2026-02-26T18:10:00.000Z');
+        expect(updated.record.skills).toEqual([
+            'route planning',
+            'meal delivery',
+        ]);
+    });
+
+    it('rejects incomplete onboarding drafts via schema validation', () => {
+        const store = new VolunteerOnboardingStore();
+
+        expect(() =>
+            store.upsertProfile({
+                ...baseDraft,
+                did: 'invalid-did',
+                skills: [],
+            }),
+        ).toThrow();
+    });
+
+    it('builds preference-aware routing candidates from stored profiles', () => {
+        const store = new VolunteerOnboardingStore();
+        store.upsertProfile(baseDraft);
+        store.upsertProfile({
+            ...baseDraft,
+            did: 'did:example:volunteer-b',
+            displayName: 'Bo',
+            capabilities: ['first-aid'],
+            availability: 'immediate',
+            matchingPreferences: {
+                preferredCategories: ['medical'],
+                preferredUrgencies: ['critical'],
+                maxDistanceKm: 8,
+                acceptsLateNight: false,
+            },
+        });
+
+        const candidates = buildVolunteerRoutingCandidates(
+            store.listProfiles(),
+            {
+                aidCategory: 'medical',
+                urgency: 'critical',
+                distanceKmByDid: {
+                    'did:example:volunteer-a': 6,
+                    'did:example:volunteer-b': 5,
+                },
+                isLateNight: false,
+            },
+        );
+
+        expect(candidates).toHaveLength(2);
+        expect(candidates[1]?.id).toBe('volunteer-b');
+        expect(candidates[1]?.preferredCategories).toEqual(['medical']);
+        expect(candidates[1]?.preferredUrgencyLevels).toEqual(['critical']);
+        expect(candidates[1]?.maxDistanceKm).toBe(8);
+    });
+
+    it('summarizes verification checkpoints deterministically', () => {
+        const summary = summarizeVolunteerCheckpoints({
+            identityCheck: 'approved',
+            safetyTraining: 'pending',
+            communityReference: 'rejected',
+        });
+
+        expect(summary).toEqual({
+            approved: 1,
+            pending: 1,
+            rejected: 1,
+        });
+    });
+});

--- a/packages/shared/src/volunteer-onboarding.ts
+++ b/packages/shared/src/volunteer-onboarding.ts
@@ -1,0 +1,281 @@
+import { z } from 'zod';
+import {
+    recordNsid,
+    type AidPostRecord,
+    type VolunteerProfileRecord,
+    validateRecordPayload,
+} from '@mutual-hub/at-lexicons';
+import type { VolunteerRoutingCandidate } from './messaging.js';
+
+const didSchema = z
+    .string()
+    .regex(/^did:[a-z0-9]+:[a-z0-9._:%-]+$/i, 'Expected a valid DID');
+
+const capabilitySchema = z.enum([
+    'transport',
+    'food-delivery',
+    'translation',
+    'first-aid',
+    'childcare',
+    'other',
+]);
+
+const checkpointStatusSchema = z.enum(['pending', 'approved', 'rejected']);
+
+const matchingPreferencesSchema = z.object({
+    preferredCategories: z
+        .array(
+            z.enum([
+                'food',
+                'shelter',
+                'medical',
+                'transport',
+                'childcare',
+                'other',
+            ]),
+        )
+        .min(1),
+    preferredUrgencies: z
+        .array(z.enum(['low', 'medium', 'high', 'critical']))
+        .min(1),
+    maxDistanceKm: z.number().min(1).max(250),
+    acceptsLateNight: z.boolean().optional(),
+});
+
+const volunteerOnboardingDraftSchema = z.object({
+    did: didSchema,
+    displayName: z.string().trim().min(1).max(80),
+    capabilities: z.array(capabilitySchema).min(1),
+    availability: z.enum([
+        'immediate',
+        'within-24h',
+        'scheduled',
+        'unavailable',
+    ]),
+    contactPreference: z.enum(['chat-only', 'chat-or-call']),
+    skills: z.array(z.string().trim().min(1).max(64)).min(1).max(50),
+    availabilityWindows: z
+        .array(z.string().trim().min(1).max(64))
+        .min(1)
+        .max(50),
+    verificationCheckpoints: z.object({
+        identityCheck: checkpointStatusSchema,
+        safetyTraining: checkpointStatusSchema,
+        communityReference: checkpointStatusSchema,
+    }),
+    matchingPreferences: matchingPreferencesSchema,
+    notes: z.string().trim().max(500).optional(),
+});
+
+export type VolunteerOnboardingDraft = z.infer<
+    typeof volunteerOnboardingDraftSchema
+>;
+
+export interface VolunteerProfileEntry {
+    did: string;
+    record: VolunteerProfileRecord;
+    verificationCheckpoints: VolunteerOnboardingDraft['verificationCheckpoints'];
+    matchingPreferences: VolunteerOnboardingDraft['matchingPreferences'];
+    updatedAt: string;
+}
+
+export interface VolunteerCheckpointSummary {
+    approved: number;
+    pending: number;
+    rejected: number;
+}
+
+const clone = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T;
+
+const normalizeStringList = (values: readonly string[]): string[] => {
+    const seen = new Map<string, string>();
+
+    for (const raw of values) {
+        const normalized = raw.trim();
+        if (normalized.length === 0) {
+            continue;
+        }
+        const key = normalized.toLowerCase();
+        if (!seen.has(key)) {
+            seen.set(key, normalized);
+        }
+    }
+
+    return [...seen.values()];
+};
+
+const normalizeDraft = (
+    input: VolunteerOnboardingDraft,
+): VolunteerOnboardingDraft => {
+    const parsed = volunteerOnboardingDraftSchema.parse(input);
+
+    return {
+        ...parsed,
+        skills: normalizeStringList(parsed.skills),
+        availabilityWindows: normalizeStringList(parsed.availabilityWindows),
+    };
+};
+
+export const summarizeVolunteerCheckpoints = (
+    checkpoints: VolunteerOnboardingDraft['verificationCheckpoints'],
+): VolunteerCheckpointSummary => {
+    const statuses = Object.values(checkpoints);
+    return {
+        approved: statuses.filter(status => status === 'approved').length,
+        pending: statuses.filter(status => status === 'pending').length,
+        rejected: statuses.filter(status => status === 'rejected').length,
+    };
+};
+
+const capabilitySupportsCategory = (
+    capability: VolunteerProfileRecord['capabilities'][number],
+    category: AidPostRecord['category'],
+): boolean => {
+    if (category === 'food') {
+        return capability === 'food-delivery';
+    }
+    if (category === 'medical') {
+        return capability === 'first-aid';
+    }
+    if (category === 'transport') {
+        return capability === 'transport';
+    }
+    if (category === 'childcare') {
+        return capability === 'childcare';
+    }
+    if (category === 'shelter') {
+        return capability === 'other';
+    }
+    return true;
+};
+
+const toRoutingCandidateId = (did: string): string => {
+    const token = did.split(':').at(-1);
+    return token && token.length > 0 ? token : did;
+};
+
+export interface VolunteerRoutingSelectionInput {
+    aidCategory: AidPostRecord['category'];
+    urgency: AidPostRecord['urgency'];
+    isLateNight?: boolean;
+    distanceKmByDid?: Record<string, number>;
+}
+
+export const buildVolunteerRoutingCandidates = (
+    profiles: readonly VolunteerProfileEntry[],
+    input: VolunteerRoutingSelectionInput,
+): VolunteerRoutingCandidate[] => {
+    const result: VolunteerRoutingCandidate[] = [];
+
+    for (const profile of profiles) {
+        if (
+            input.isLateNight &&
+            profile.matchingPreferences.acceptsLateNight === false
+        ) {
+            continue;
+        }
+
+        const distanceKm = input.distanceKmByDid?.[profile.did];
+
+        const checkpointSummary = summarizeVolunteerCheckpoints(
+            profile.verificationCheckpoints,
+        );
+
+        const verificationCheckpointScore =
+            checkpointSummary.approved /
+            Math.max(
+                1,
+                checkpointSummary.approved +
+                    checkpointSummary.pending +
+                    checkpointSummary.rejected,
+            );
+
+        const capabilityMatch = profile.record.capabilities.some(capability =>
+            capabilitySupportsCategory(capability, input.aidCategory),
+        );
+        const preferenceMatch =
+            profile.matchingPreferences.preferredCategories.includes(
+                input.aidCategory,
+            );
+
+        result.push({
+            id: toRoutingCandidateId(profile.did),
+            did: profile.did,
+            availability: profile.record.availability,
+            trustScore: Number(
+                (0.5 + verificationCheckpointScore * 0.4).toFixed(3),
+            ),
+            matchesCategory: capabilityMatch || preferenceMatch,
+            preferredCategories: [
+                ...profile.matchingPreferences.preferredCategories,
+            ],
+            preferredUrgencyLevels: [
+                ...profile.matchingPreferences.preferredUrgencies,
+            ],
+            maxDistanceKm: profile.matchingPreferences.maxDistanceKm,
+            distanceKm,
+            verificationCheckpointScore: Number(
+                verificationCheckpointScore.toFixed(3),
+            ),
+        });
+    }
+
+    return result.sort((left, right) => left.id.localeCompare(right.id));
+};
+
+export class VolunteerOnboardingStore {
+    private readonly entries = new Map<string, VolunteerProfileEntry>();
+
+    upsertProfile(
+        input: VolunteerOnboardingDraft,
+        options: { now?: string } = {},
+    ): VolunteerProfileEntry {
+        const normalized = normalizeDraft(input);
+        const now = options.now ?? new Date().toISOString();
+        const existing = this.entries.get(normalized.did);
+
+        const recordCandidate: VolunteerProfileRecord = {
+            $type: recordNsid.volunteerProfile,
+            version: '1.1.0',
+            displayName: normalized.displayName,
+            capabilities: normalized.capabilities,
+            availability: normalized.availability,
+            contactPreference: normalized.contactPreference,
+            skills: normalized.skills,
+            availabilityWindows: normalized.availabilityWindows,
+            verificationCheckpoints: normalized.verificationCheckpoints,
+            matchingPreferences: normalized.matchingPreferences,
+            notes: normalized.notes,
+            createdAt: existing?.record.createdAt ?? now,
+            updatedAt: now,
+        };
+
+        const record = validateRecordPayload(
+            recordNsid.volunteerProfile,
+            recordCandidate,
+        );
+
+        const entry: VolunteerProfileEntry = {
+            did: normalized.did,
+            record,
+            verificationCheckpoints: normalized.verificationCheckpoints,
+            matchingPreferences: normalized.matchingPreferences,
+            updatedAt: now,
+        };
+
+        this.entries.set(normalized.did, entry);
+        return clone(entry);
+    }
+
+    getProfile(did: string): VolunteerProfileEntry | null {
+        const parsedDid = didSchema.parse(did);
+        const found = this.entries.get(parsedDid);
+        return found ? clone(found) : null;
+    }
+
+    listProfiles(): VolunteerProfileEntry[] {
+        return [...this.entries.values()]
+            .sort((left, right) => left.did.localeCompare(right.did))
+            .map(value => clone(value));
+    }
+}

--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -8,10 +8,12 @@ import {
 } from '@mutual-hub/shared';
 import { createFixtureChatService } from './chat-service.js';
 import { createFixtureQueryService } from './query-service.js';
+import { createFixtureVolunteerService } from './volunteer-service.js';
 
 const config = loadApiConfig();
 const queryService = createFixtureQueryService();
 const chatService = createFixtureChatService();
+const volunteerService = createFixtureVolunteerService();
 
 const healthPayload: ServiceHealth = {
     service: 'api',
@@ -53,6 +55,9 @@ export const createApiServer = () => {
                     '/chat/safety/mute',
                     '/chat/safety/report',
                     '/chat/safety/signals/drain',
+                    '/chat/route/preference-aware',
+                    '/volunteer/profile/upsert',
+                    '/volunteer/profiles',
                     '/health',
                 ],
             });
@@ -78,7 +83,9 @@ export const createApiServer = () => {
         }
 
         if (requestUrl.pathname === '/chat/initiate') {
-            const result = chatService.initiateFromParams(requestUrl.searchParams);
+            const result = chatService.initiateFromParams(
+                requestUrl.searchParams,
+            );
             writeJson(response, result.statusCode, result.body);
             return;
         }
@@ -120,13 +127,37 @@ export const createApiServer = () => {
         }
 
         if (requestUrl.pathname === '/chat/safety/report') {
-            const result = chatService.reportFromParams(requestUrl.searchParams);
+            const result = chatService.reportFromParams(
+                requestUrl.searchParams,
+            );
             writeJson(response, result.statusCode, result.body);
             return;
         }
 
         if (requestUrl.pathname === '/chat/safety/signals/drain') {
             const result = chatService.drainModerationSignals();
+            writeJson(response, result.statusCode, result.body);
+            return;
+        }
+
+        if (requestUrl.pathname === '/chat/route/preference-aware') {
+            const result = volunteerService.routePreferenceAwareFromParams(
+                requestUrl.searchParams,
+            );
+            writeJson(response, result.statusCode, result.body);
+            return;
+        }
+
+        if (requestUrl.pathname === '/volunteer/profile/upsert') {
+            const result = volunteerService.upsertFromParams(
+                requestUrl.searchParams,
+            );
+            writeJson(response, result.statusCode, result.body);
+            return;
+        }
+
+        if (requestUrl.pathname === '/volunteer/profiles') {
+            const result = volunteerService.listFromParams();
             writeJson(response, result.statusCode, result.body);
             return;
         }

--- a/services/api/src/phase6.test.ts
+++ b/services/api/src/phase6.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+import { createFixtureVolunteerService } from './volunteer-service.js';
+
+describe('api phase 6 volunteer onboarding + preference routing', () => {
+    it('creates and updates volunteer profiles through API params', () => {
+        const service = createFixtureVolunteerService();
+
+        const created = service.upsertFromParams(
+            new URLSearchParams({
+                did: 'did:example:volunteer-a',
+                displayName: 'Ari',
+                capabilities: 'transport,food-delivery',
+                availability: 'within-24h',
+                contactPreference: 'chat-or-call',
+                skills: 'route planning,meal delivery',
+                availabilityWindows: 'weekday_evenings,weekend_mornings',
+                checkpointIdentity: 'approved',
+                checkpointSafety: 'approved',
+                checkpointReference: 'pending',
+                preferredCategories: 'food,transport',
+                preferredUrgencies: 'medium,high,critical',
+                maxDistanceKm: '15',
+                acceptsLateNight: 'true',
+                now: '2026-02-26T18:00:00.000Z',
+            }),
+        );
+
+        expect(created.statusCode).toBe(200);
+
+        const updated = service.upsertFromParams(
+            new URLSearchParams({
+                did: 'did:example:volunteer-a',
+                displayName: 'Ari N.',
+                capabilities: 'transport,food-delivery',
+                availability: 'immediate',
+                contactPreference: 'chat-only',
+                skills: 'route planning,meal delivery',
+                availabilityWindows: 'weekday_evenings',
+                checkpointIdentity: 'approved',
+                checkpointSafety: 'approved',
+                checkpointReference: 'approved',
+                preferredCategories: 'food',
+                preferredUrgencies: 'high,critical',
+                maxDistanceKm: '12',
+                acceptsLateNight: 'false',
+                now: '2026-02-26T18:10:00.000Z',
+            }),
+        );
+
+        expect(updated.statusCode).toBe(200);
+
+        const listed = service.listFromParams();
+        expect(listed.statusCode).toBe(200);
+        expect(listed.body).toMatchObject({
+            total: 1,
+            results: [
+                {
+                    did: 'did:example:volunteer-a',
+                    record: {
+                        displayName: 'Ari N.',
+                        availability: 'immediate',
+                    },
+                },
+            ],
+        });
+    });
+
+    it('uses stored volunteer preferences in deterministic routing decisions', () => {
+        const service = createFixtureVolunteerService();
+
+        service.upsertFromParams(
+            new URLSearchParams({
+                did: 'did:example:volunteer-a',
+                displayName: 'Ari',
+                capabilities: 'transport',
+                availability: 'immediate',
+                contactPreference: 'chat-only',
+                skills: 'route planning',
+                availabilityWindows: 'weekday_evenings',
+                checkpointIdentity: 'approved',
+                checkpointSafety: 'approved',
+                checkpointReference: 'approved',
+                preferredCategories: 'transport',
+                preferredUrgencies: 'high,critical',
+                maxDistanceKm: '20',
+            }),
+        );
+
+        service.upsertFromParams(
+            new URLSearchParams({
+                did: 'did:example:volunteer-b',
+                displayName: 'Bo',
+                capabilities: 'first-aid',
+                availability: 'immediate',
+                contactPreference: 'chat-only',
+                skills: 'triage',
+                availabilityWindows: 'weekday_evenings',
+                checkpointIdentity: 'approved',
+                checkpointSafety: 'approved',
+                checkpointReference: 'approved',
+                preferredCategories: 'medical',
+                preferredUrgencies: 'critical',
+                maxDistanceKm: '12',
+            }),
+        );
+
+        const routed = service.routePreferenceAwareFromParams(
+            new URLSearchParams({
+                aidPostUri:
+                    'at://did:example:requester/app.mutualhub.aid.post/phase6-route',
+                requesterDid: 'did:example:requester',
+                category: 'medical',
+                urgency: 'critical',
+                now: '2026-02-26T18:20:00.000Z',
+            }),
+        );
+
+        expect(routed.statusCode).toBe(200);
+        expect(routed.body).toMatchObject({
+            decision: {
+                matchedRule: 'RULE_VOLUNTEER_POOL',
+                destinationId: 'volunteer:volunteer-b',
+            },
+        });
+    });
+});

--- a/services/api/src/query-service.ts
+++ b/services/api/src/query-service.ts
@@ -141,6 +141,10 @@ export class ApiDiscoveryQueryService {
             const input = validateDirectoryQueryInput({
                 category: readString(params, 'category'),
                 status: readString(params, 'status'),
+                operationalStatus: readString(params, 'operationalStatus'),
+                latitude: readNumber(params, 'latitude'),
+                longitude: readNumber(params, 'longitude'),
+                radiusKm: readNumber(params, 'radiusKm'),
                 freshnessHours: readNumber(params, 'freshnessHours'),
                 searchText: readString(params, 'searchText'),
                 page: readNumber(params, 'page'),

--- a/services/api/src/smoke.test.ts
+++ b/services/api/src/smoke.test.ts
@@ -3,6 +3,6 @@ import { CONTRACT_VERSION } from '@mutual-hub/shared';
 
 describe('api service shell', () => {
     it('references shared contracts', () => {
-        expect(CONTRACT_VERSION).toContain('phase5');
+        expect(CONTRACT_VERSION).toContain('phase6');
     });
 });

--- a/services/api/src/volunteer-service.ts
+++ b/services/api/src/volunteer-service.ts
@@ -1,0 +1,243 @@
+import {
+    DeterministicRoutingAssistant,
+    VolunteerOnboardingStore,
+    buildVolunteerRoutingCandidates,
+    type AidPostRecord,
+} from '@mutual-hub/shared';
+
+export interface ApiVolunteerRouteResult {
+    statusCode: number;
+    body: unknown;
+}
+
+const readString = (
+    params: URLSearchParams,
+    key: string,
+): string | undefined => {
+    const value = params.get(key);
+    if (value === null || value.trim() === '') {
+        return undefined;
+    }
+
+    return value;
+};
+
+const requireString = (params: URLSearchParams, key: string): string => {
+    const value = readString(params, key);
+    if (!value) {
+        throw new Error(`Missing required field: ${key}`);
+    }
+
+    return value;
+};
+
+const parseList = (value: string | undefined): string[] => {
+    if (!value) {
+        return [];
+    }
+
+    return value
+        .split(',')
+        .map(item => item.trim())
+        .filter(Boolean);
+};
+
+const parseAidCategory = (
+    value: string | undefined,
+): AidPostRecord['category'] => {
+    if (
+        value === 'food' ||
+        value === 'shelter' ||
+        value === 'medical' ||
+        value === 'transport' ||
+        value === 'childcare' ||
+        value === 'other'
+    ) {
+        return value;
+    }
+
+    return 'other';
+};
+
+const parseUrgency = (value: string | undefined): AidPostRecord['urgency'] => {
+    if (
+        value === 'low' ||
+        value === 'medium' ||
+        value === 'high' ||
+        value === 'critical'
+    ) {
+        return value;
+    }
+
+    return 'medium';
+};
+
+const parseCheckpointStatus = (
+    value: string | undefined,
+): 'pending' | 'approved' | 'rejected' => {
+    if (value === 'approved' || value === 'rejected' || value === 'pending') {
+        return value;
+    }
+
+    return 'pending';
+};
+
+export class ApiVolunteerService {
+    private readonly store = new VolunteerOnboardingStore();
+    private readonly routingAssistant = new DeterministicRoutingAssistant();
+
+    upsertFromParams(params: URLSearchParams): ApiVolunteerRouteResult {
+        try {
+            const now = readString(params, 'now');
+            const entry = this.store.upsertProfile(
+                {
+                    did: requireString(params, 'did'),
+                    displayName: requireString(params, 'displayName'),
+                    capabilities: parseList(
+                        readString(params, 'capabilities'),
+                    ) as Array<
+                        | 'transport'
+                        | 'food-delivery'
+                        | 'translation'
+                        | 'first-aid'
+                        | 'childcare'
+                        | 'other'
+                    >,
+                    availability:
+                        (readString(params, 'availability') as
+                            | 'immediate'
+                            | 'within-24h'
+                            | 'scheduled'
+                            | 'unavailable'
+                            | undefined) ?? 'scheduled',
+                    contactPreference:
+                        (readString(params, 'contactPreference') as
+                            | 'chat-only'
+                            | 'chat-or-call'
+                            | undefined) ?? 'chat-only',
+                    skills: parseList(readString(params, 'skills')),
+                    availabilityWindows: parseList(
+                        readString(params, 'availabilityWindows'),
+                    ),
+                    verificationCheckpoints: {
+                        identityCheck: parseCheckpointStatus(
+                            readString(params, 'checkpointIdentity'),
+                        ),
+                        safetyTraining: parseCheckpointStatus(
+                            readString(params, 'checkpointSafety'),
+                        ),
+                        communityReference: parseCheckpointStatus(
+                            readString(params, 'checkpointReference'),
+                        ),
+                    },
+                    matchingPreferences: {
+                        preferredCategories: parseList(
+                            readString(params, 'preferredCategories'),
+                        ) as AidPostRecord['category'][],
+                        preferredUrgencies: parseList(
+                            readString(params, 'preferredUrgencies'),
+                        ) as AidPostRecord['urgency'][],
+                        maxDistanceKm: Number(
+                            readString(params, 'maxDistanceKm') ?? '10',
+                        ),
+                        acceptsLateNight:
+                            readString(params, 'acceptsLateNight') === 'true',
+                    },
+                    notes: readString(params, 'notes'),
+                },
+                { now },
+            );
+
+            return {
+                statusCode: 200,
+                body: {
+                    did: entry.did,
+                    record: entry.record,
+                    matchingPreferences: entry.matchingPreferences,
+                },
+            };
+        } catch (error) {
+            return {
+                statusCode: 400,
+                body: {
+                    error: {
+                        code: 'INVALID_VOLUNTEER_PROFILE',
+                        message:
+                            error instanceof Error ?
+                                error.message
+                            :   'Failed to upsert volunteer profile',
+                    },
+                },
+            };
+        }
+    }
+
+    listFromParams(): ApiVolunteerRouteResult {
+        const profiles = this.store.listProfiles();
+        return {
+            statusCode: 200,
+            body: {
+                total: profiles.length,
+                results: profiles,
+            },
+        };
+    }
+
+    routePreferenceAwareFromParams(
+        params: URLSearchParams,
+    ): ApiVolunteerRouteResult {
+        try {
+            const aidCategory = parseAidCategory(
+                readString(params, 'category'),
+            );
+            const urgency = parseUrgency(readString(params, 'urgency'));
+            const candidates = buildVolunteerRoutingCandidates(
+                this.store.listProfiles(),
+                {
+                    aidCategory,
+                    urgency,
+                    isLateNight: readString(params, 'isLateNight') === 'true',
+                },
+            );
+
+            const decision = this.routingAssistant.decide({
+                aidPostUri:
+                    readString(params, 'aidPostUri') ??
+                    'at://did:example:requester/app.mutualhub.aid.post/preference-route',
+                requesterDid:
+                    readString(params, 'requesterDid') ??
+                    'did:example:requester',
+                aidCategory,
+                urgency,
+                volunteerCandidates: candidates,
+                resourceCandidates: [],
+                now: readString(params, 'now'),
+            });
+
+            return {
+                statusCode: 200,
+                body: {
+                    candidateCount: candidates.length,
+                    decision,
+                },
+            };
+        } catch (error) {
+            return {
+                statusCode: 400,
+                body: {
+                    error: {
+                        code: 'INVALID_ROUTE_INPUT',
+                        message:
+                            error instanceof Error ?
+                                error.message
+                            :   'Failed to compute preference-aware route',
+                    },
+                },
+            };
+        }
+    }
+}
+
+export const createFixtureVolunteerService = (): ApiVolunteerService => {
+    return new ApiVolunteerService();
+};

--- a/services/indexer/src/smoke.test.ts
+++ b/services/indexer/src/smoke.test.ts
@@ -3,6 +3,6 @@ import { CONTRACT_VERSION } from '@mutual-hub/shared';
 
 describe('indexer service shell', () => {
     it('references shared contracts', () => {
-        expect(CONTRACT_VERSION).toBe('0.5.0-phase5');
+        expect(CONTRACT_VERSION).toBe('0.6.0-phase6');
     });
 });


### PR DESCRIPTION
## Summary
- implement Phase 6 directory record ingestion/indexing metadata (location overlays, open-hours, eligibility notes, operational status)
- add volunteer onboarding/profile management domain + API routes + preference-aware routing inputs
- add web resource-directory overlay/detail UX and volunteer onboarding state/tests
- update lexicon/schema revisions, shared contracts/docs, and service smoke tests to Phase 6 baseline

## Verification
- npm run check

## Roadmap / issue linkage
- Refs #41
- Closes #27
- Closes #29
- Closes #30
- Closes #32