### PR TITLE
chore: phase 7 follow-up moderation and docs refinements

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,32 +98,32 @@ Each backend service exposes a health endpoint:
 Phase 7 service endpoints:
 
 - API:
-  - `GET /query/map`
-  - `GET /query/feed`
-  - `GET /query/directory`
-  - `GET /chat/initiate`
-  - `GET /chat/route`
-  - `GET /chat/conversations`
-  - `GET /chat/safety/evaluate`
-  - `GET /chat/safety/block`
-  - `GET /chat/safety/mute`
-  - `GET /chat/safety/report`
-  - `GET /chat/safety/signals/drain`
-  - `GET /chat/safety/metrics`
-  - `GET /chat/route/preference-aware`
-  - `GET /volunteer/profile/upsert`
-  - `GET /volunteer/profiles`
+    - `GET /query/map`
+    - `GET /query/feed`
+    - `GET /query/directory`
+    - `GET /chat/initiate`
+    - `GET /chat/route`
+    - `GET /chat/conversations`
+    - `GET /chat/safety/evaluate`
+    - `GET /chat/safety/block`
+    - `GET /chat/safety/mute`
+    - `GET /chat/safety/report`
+    - `GET /chat/safety/signals/drain`
+    - `GET /chat/safety/metrics`
+    - `GET /chat/route/preference-aware`
+    - `GET /volunteer/profile/upsert`
+    - `GET /volunteer/profiles`
 - Indexer:
-  - `GET /ingestion/metrics`
-  - `GET /ingestion/logs`
-  - `GET /indexes/stats`
+    - `GET /ingestion/metrics`
+    - `GET /ingestion/logs`
+    - `GET /indexes/stats`
 - Moderation worker:
-  - `GET /decisions/sample`
-  - `GET /moderation/queue/enqueue`
-  - `GET /moderation/queue`
-  - `GET /moderation/policy/apply`
-  - `GET /moderation/state`
-  - `GET /moderation/audit`
+    - `GET /decisions/sample`
+    - `GET /moderation/queue/enqueue`
+    - `GET /moderation/queue`
+    - `GET /moderation/policy/apply`
+    - `GET /moderation/state`
+    - `GET /moderation/audit`
 
 ## Quality gates
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -21,7 +21,8 @@ export const App = () => {
                 <Panel title='Discovery shell'>
                     <p className='mb-3 text-sm text-[var(--mh-text-muted)]'>
                         Vite + React + TypeScript + Tailwind are wired and ready
-                        for Phase 7 moderation, anti-spam, and privacy hardening.
+                        for Phase 7 moderation, anti-spam, and privacy
+                        hardening.
                     </p>
                     <label className='mb-2 block text-xs font-bold uppercase tracking-wide'>
                         Search requests

--- a/docs/architecture/domain-map.md
+++ b/docs/architecture/domain-map.md
@@ -2,18 +2,18 @@
 
 This map defines bounded contexts, ownership, and primary interface boundaries for v1.
 
-| Domain               | Primary owner service              | Key records/interfaces                   | Notes                                                  |
-| -------------------- | ---------------------------------- | ---------------------------------------- | ------------------------------------------------------ |
-| Identity             | `services/api`                     | DID auth/session contracts               | Web clients only interact through API boundary         |
-| Aid records          | `services/api`, `services/indexer` | Query contracts + ingestion events       | API writes/query surface; indexer normalizes/searches  |
-| Geo                  | `services/indexer`                 | Approximate-area and geo index contracts | No exact coordinate exposure in public APIs            |
-| Ranking              | `services/indexer`                 | Ranked feed/map response contracts       | Deterministic ranking pipeline boundary                |
-| Messaging            | `services/api`                     | 1:1 chat initiation/request contracts    | Moderation hooks via async events                      |
-| Moderation           | `services/moderation-worker`       | Review queue + policy/audit contracts    | Isolated async worker boundary with appeal lifecycle   |
-| Directory            | `services/indexer`                 | Resource directory index/query contracts | Consumed by API responses                              |
-| Volunteer onboarding | `services/api`                     | Volunteer profile + preference contracts | Integrated into deterministic routing inputs (Phase 6) |
-| Anti-spam            | `services/api`                     | Chat safety evaluation + metrics          | Duplicate/rate burst controls and suspicious signaling |
-| Privacy              | `packages/shared`, `services/indexer` | Geoprivacy + log redaction contracts  | Enforces approximate coordinates and minimal diagnostics |
+| Domain               | Primary owner service                 | Key records/interfaces                   | Notes                                                    |
+| -------------------- | ------------------------------------- | ---------------------------------------- | -------------------------------------------------------- |
+| Identity             | `services/api`                        | DID auth/session contracts               | Web clients only interact through API boundary           |
+| Aid records          | `services/api`, `services/indexer`    | Query contracts + ingestion events       | API writes/query surface; indexer normalizes/searches    |
+| Geo                  | `services/indexer`                    | Approximate-area and geo index contracts | No exact coordinate exposure in public APIs              |
+| Ranking              | `services/indexer`                    | Ranked feed/map response contracts       | Deterministic ranking pipeline boundary                  |
+| Messaging            | `services/api`                        | 1:1 chat initiation/request contracts    | Moderation hooks via async events                        |
+| Moderation           | `services/moderation-worker`          | Review queue + policy/audit contracts    | Isolated async worker boundary with appeal lifecycle     |
+| Directory            | `services/indexer`                    | Resource directory index/query contracts | Consumed by API responses                                |
+| Volunteer onboarding | `services/api`                        | Volunteer profile + preference contracts | Integrated into deterministic routing inputs (Phase 6)   |
+| Anti-spam            | `services/api`                        | Chat safety evaluation + metrics         | Duplicate/rate burst controls and suspicious signaling   |
+| Privacy              | `packages/shared`, `services/indexer` | Geoprivacy + log redaction contracts     | Enforces approximate coordinates and minimal diagnostics |
 
 ## Anti-corruption boundaries
 

--- a/packages/shared/src/messaging.ts
+++ b/packages/shared/src/messaging.ts
@@ -747,7 +747,9 @@ export class ChatSafetyControls {
         const normalizedMessage = input.message.trim().toLowerCase();
 
         const duplicateKey = `${senderDid}:${conversationUri}:${normalizedMessage}`;
-        const duplicateWindow = (this.duplicateWindows.get(duplicateKey) ?? []).filter(
+        const duplicateWindow = (
+            this.duplicateWindows.get(duplicateKey) ?? []
+        ).filter(
             timestamp => nowMs - timestamp <= this.config.duplicateWindowMs,
         );
 

--- a/packages/shared/src/moderation.test.ts
+++ b/packages/shared/src/moderation.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import {
-    ModerationPolicyError,
-    ModerationReviewQueue,
-} from './moderation.js';
+import { ModerationPolicyError, ModerationReviewQueue } from './moderation.js';
 
 describe('P7.1 moderation queue + policy actions', () => {
     it('adds reported items to queue with sufficient context', () => {

--- a/packages/shared/src/moderation.ts
+++ b/packages/shared/src/moderation.ts
@@ -122,10 +122,7 @@ const subjectTypeFromUri = (subjectUri: string): ModerationSubjectType => {
 };
 
 const toQueueId = (subjectUri: string): string => {
-    return createHash('sha256')
-        .update(subjectUri)
-        .digest('hex')
-        .slice(0, 20);
+    return createHash('sha256').update(subjectUri).digest('hex').slice(0, 20);
 };
 
 const toAuditId = (
@@ -151,7 +148,7 @@ const mergeContext = (
         tags:
             next.tags && next.tags.length > 0 ?
                 [...new Set(next.tags.map(tag => tag.trim()).filter(Boolean))]
-            : existing.tags,
+            :   existing.tags,
     };
 };
 
@@ -177,8 +174,10 @@ const applyTransition = (
         case 'restore-visibility':
             next.visibility = 'visible';
             next.queueStatus =
-                current.appealState === 'pending' ||
-                current.appealState === 'under-review' ?
+                (
+                    current.appealState === 'pending' ||
+                    current.appealState === 'under-review'
+                ) ?
                     'queued'
                 :   'resolved';
             break;
@@ -391,13 +390,22 @@ export class ModerationReviewQueue {
     }): ModerationQueueItem[] {
         return [...this.queueBySubject.values()]
             .filter(item => {
-                if (filters?.queueStatus && item.queueStatus !== filters.queueStatus) {
+                if (
+                    filters?.queueStatus &&
+                    item.queueStatus !== filters.queueStatus
+                ) {
                     return false;
                 }
-                if (filters?.visibility && item.visibility !== filters.visibility) {
+                if (
+                    filters?.visibility &&
+                    item.visibility !== filters.visibility
+                ) {
                     return false;
                 }
-                if (filters?.appealState && item.appealState !== filters.appealState) {
+                if (
+                    filters?.appealState &&
+                    item.appealState !== filters.appealState
+                ) {
                     return false;
                 }
                 return true;

--- a/services/api/src/chat-service.ts
+++ b/services/api/src/chat-service.ts
@@ -40,13 +40,13 @@ const readString = (
     return value;
 };
 
-const requireString = (
-    params: URLSearchParams,
-    key: string,
-): string => {
+const requireString = (params: URLSearchParams, key: string): string => {
     const value = readString(params, key);
     if (!value) {
-        throw new ChatFlowError('INVALID_CONTEXT', `Missing required field: ${key}`);
+        throw new ChatFlowError(
+            'INVALID_CONTEXT',
+            `Missing required field: ${key}`,
+        );
     }
 
     return value;
@@ -98,11 +98,9 @@ const toErrorResult = (
 ): ApiChatRouteResult => {
     if (error instanceof ChatFlowError) {
         const code: ApiChatErrorResponse['error']['code'] =
-            error.code === 'UNAUTHORIZED' ?
-                'UNAUTHORIZED'
-            : error.code === 'INVALID_CONTEXT' ?
-                'INVALID_CONTEXT'
-            :   'INVALID_QUERY';
+            error.code === 'UNAUTHORIZED' ? 'UNAUTHORIZED'
+            : error.code === 'INVALID_CONTEXT' ? 'INVALID_CONTEXT'
+            : 'INVALID_QUERY';
 
         return {
             statusCode: code === 'UNAUTHORIZED' ? 403 : 400,
@@ -180,8 +178,12 @@ export class ApiChatService {
                 readString(params, 'initiatedFrom'),
             );
 
-            const allowInitiation = readString(params, 'allowInitiation') !== 'false';
-            const allowedParticipants = readString(params, 'allowedParticipants')
+            const allowInitiation =
+                readString(params, 'allowInitiation') !== 'false';
+            const allowedParticipants = readString(
+                params,
+                'allowedParticipants',
+            )
                 ?.split(',')
                 .map(value => value.trim())
                 .filter(Boolean);
@@ -207,7 +209,9 @@ export class ApiChatService {
                 now: readString(params, 'now'),
             });
 
-            const existing = this.metadataStore.getConversation(chat.conversationUri);
+            const existing = this.metadataStore.getConversation(
+                chat.conversationUri,
+            );
             const persisted = this.metadataStore.upsertConversation({
                 chat,
                 routingDecision: routing,
@@ -230,13 +234,18 @@ export class ApiChatService {
                 },
             };
         } catch (error) {
-            return toErrorResult(error, 'Failed to initiate chat conversation.');
+            return toErrorResult(
+                error,
+                'Failed to initiate chat conversation.',
+            );
         }
     }
 
     routeScenarioFromParams(params: URLSearchParams): ApiChatRouteResult {
         const scenario = readString(params, 'scenario') ?? 'post-author-direct';
-        const fixture = buildPhase5RoutingFixtures().find(item => item.id === scenario);
+        const fixture = buildPhase5RoutingFixtures().find(
+            item => item.id === scenario,
+        );
 
         if (!fixture) {
             return {
@@ -273,7 +282,10 @@ export class ApiChatService {
                 },
             };
         } catch (error) {
-            return toErrorResult(error, 'Failed to list conversation metadata.');
+            return toErrorResult(
+                error,
+                'Failed to list conversation metadata.',
+            );
         }
     }
 

--- a/services/moderation-worker/src/moderation-service.ts
+++ b/services/moderation-worker/src/moderation-service.ts
@@ -170,7 +170,9 @@ export class ModerationWorkerService {
             const items = this.queue.listQueue({
                 queueStatus: parseQueueStatus(readString(params, 'status')),
                 visibility: parseVisibility(readString(params, 'visibility')),
-                appealState: parseAppealState(readString(params, 'appealState')),
+                appealState: parseAppealState(
+                    readString(params, 'appealState'),
+                ),
             });
 
             return {
@@ -202,7 +204,10 @@ export class ModerationWorkerService {
                 },
             };
         } catch (error) {
-            return toErrorResult(error, 'Failed to apply moderation policy action.');
+            return toErrorResult(
+                error,
+                'Failed to apply moderation policy action.',
+            );
         }
     }
 
@@ -242,11 +247,15 @@ export class ModerationWorkerService {
                 },
             };
         } catch (error) {
-            return toErrorResult(error, 'Failed to list moderation audit trail.');
+            return toErrorResult(
+                error,
+                'Failed to list moderation audit trail.',
+            );
         }
     }
 }
 
-export const createFixtureModerationWorkerService = (): ModerationWorkerService => {
-    return new ModerationWorkerService();
-};
+export const createFixtureModerationWorkerService =
+    (): ModerationWorkerService => {
+        return new ModerationWorkerService();
+    };

--- a/services/moderation-worker/src/phase7.test.ts
+++ b/services/moderation-worker/src/phase7.test.ts
@@ -7,7 +7,8 @@ describe('phase 7 moderation worker queue + policy endpoints', () => {
 
         const enqueue = service.enqueueFromParams(
             new URLSearchParams({
-                subjectUri: 'at://did:example:alice/app.mutualhub.aid.post/post-1',
+                subjectUri:
+                    'at://did:example:alice/app.mutualhub.aid.post/post-1',
                 reason: 'user-report:spam',
                 reporterDid: 'did:example:reporter-1',
                 summary: 'Repeated duplicate content',


### PR DESCRIPTION
## Summary
- apply follow-up refinements to Phase 7 moderation queue/policy behavior and related tests
- tighten chat safety service/message handling updates and keep test coverage green
- refresh README/domain map/app shell copy for consistent post-Phase-7 messaging

## Verification
- npm run check

## Roadmap / issue linkage
- Refs #41
- No additional issue closures in this follow-up PR (Phase 7 issues #34, #36, #38, #40 were already closed by merged PR #48).