### PR TITLE
fix: restore Phase 7 API regression gate coverage

### DIFF
--- a/services/api/package.json
+++ b/services/api/package.json
@@ -10,7 +10,7 @@
         "lint": "npm run typecheck",
         "typecheck": "tsc -p tsconfig.json --noEmit",
         "test": "vitest run",
-        "test:phase7": "vitest run src/phase7.test.ts"
+        "test:phase7": "vitest run src/phase5.test.ts src/phase7.test.ts"
     },
     "dependencies": {
         "@mutual-hub/shared": "0.1.0"


### PR DESCRIPTION
## Summary
- restore API Phase 7 regression gate scope to include both `phase5` and `phase7` safety tests
- keep workspace `test:phase7` behavior aligned with roadmap Phase 7 moderation/privacy release-gate intent

## Verification
- npm run test:phase7
- npm run check

## Roadmap / issue linkage
- Refs #41

## Issues closure status
- No additional issues will be closed by this merge.
- Phase 7 implementation issues were already closed by merged PR #48:
  - #34
  - #36
  - #38
  - #40